### PR TITLE
Adding !found condition to the for loop through sites to stop processing once resource found.

### DIFF
--- a/mso/resource_mso_schema_site_bd_subnet.go
+++ b/mso/resource_mso_schema_site_bd_subnet.go
@@ -105,7 +105,7 @@ func resourceMSOSchemaSiteBdSubnetImport(d *schema.ResourceData, m interface{}) 
 	found := false
 	stateBd := get_attribute[4]
 	stateIp := import_split[2]
-	for i := 0; i < count; i++ {
+	for i := 0; i < count && !found; i++ {
 		tempCont, err := cont.ArrayElement(i, "sites")
 		if err != nil {
 			return nil, err

--- a/mso/resource_mso_schema_site_bd_subnet.go
+++ b/mso/resource_mso_schema_site_bd_subnet.go
@@ -243,7 +243,7 @@ func resourceMSOSchemaSiteBdSubnetRead(d *schema.ResourceData, m interface{}) er
 	stateTemplate := d.Get("template_name").(string)
 	stateBd := d.Get("bd_name").(string)
 	stateIp := d.Get("ip").(string)
-	for i := 0; i < count; i++ {
+	for i := 0; i < count && !found; i++ {
 		tempCont, err := cont.ArrayElement(i, "sites")
 		if err != nil {
 			return err
@@ -364,7 +364,9 @@ func resourceMSOSchemaSiteBdSubnetUpdate(d *schema.ResourceData, m interface{}) 
 	if err != nil {
 		return fmt.Errorf("No Site found")
 	}
-	for i := 0; i < count; i++ {
+	updated := false
+
+	for i := 0; i < count && !updated; i++ {
 		tempCont, err := cont.ArrayElement(i, "sites")
 		if err != nil {
 			return err
@@ -410,6 +412,7 @@ func resourceMSOSchemaSiteBdSubnetUpdate(d *schema.ResourceData, m interface{}) 
 							if err != nil {
 								return err
 							}
+							updated = true
 						}
 
 					}
@@ -470,7 +473,10 @@ func resourceMSOSchemaSiteBdSubnetDelete(d *schema.ResourceData, m interface{}) 
 	if err != nil {
 		return fmt.Errorf("No Sites found")
 	}
-	for i := 0; i < count; i++ {
+
+	deleted := false
+
+	for i := 0; i < count && !deleted; i++ {
 		tempCont, err := cont.ArrayElement(i, "sites")
 		if err != nil {
 			return err
@@ -512,6 +518,7 @@ func resourceMSOSchemaSiteBdSubnetDelete(d *schema.ResourceData, m interface{}) 
 							if err != nil && !(response.Exists("code") && response.S("code").String() == "141") {
 								return err
 							}
+							deleted = true
 						}
 					}
 				}


### PR DESCRIPTION
Fixes issue #119 

Where multiple templates are associated to a site there will be multiple entries in the sites list. The for loop does not break once the resource is found (the break on line 163 has no effect at the top level - though I've left that in for now).

I've added a !found condition to the sites for loop, so that once a resource is found, the loop will stop processing and it can return to Terraform.