### PR TITLE
[bugfix] add check for contract type in mso_schema_template_external_epg_contract

### DIFF
--- a/examples/schema_template_external_epg_contract/main.tf
+++ b/examples/schema_template_external_epg_contract/main.tf
@@ -13,12 +13,86 @@ provider "mso" {
   insecure = true
 }
 
-resource "mso_schema_template_external_epg_contract" "c1" {
-  schema_id                 = "5ea809672c00003bc40a2799"
-  template_name             = "Template1"
-  contract_name             = "contractdemo"
-  external_epg_name         = "UntitledExternalEPG1"
+resource "mso_tenant" "test_tenant" {
+  name         = "eepg_contract_tenant"
+  display_name = "eepg_contract_tenant"
+  description  = "DemoTenant"
+}
+
+resource "mso_schema" "test_schema" {
+  name          = "eepg_contract_schema"
+  template_name = "eepg_contract_template"
+  tenant_id     = mso_tenant.test_tenant.id
+}
+
+resource "mso_schema_template_vrf" "test_vrf" {
+  schema_id        = mso_schema.test_schema.id
+  template         = mso_schema.test_schema.template_name
+  name             = "eepg_contract_vrf"
+  display_name     = "eepg_contract_vrf"
+  layer3_multicast = false
+}
+
+resource "mso_schema_template_external_epg" "template_externalepg" {
+  schema_id         = mso_schema.test_schema.id
+  template_name     = mso_schema.test_schema.template_name
+  external_epg_name = "eepg"
+  display_name      = "eepg"
+  vrf_name          = mso_schema_template_vrf.test_vrf.name
+  external_epg_type = "on-premise"
+}
+
+resource "mso_schema_template_filter_entry" "filter_entry" {
+  schema_id            = mso_schema.test_schema.id
+  template_name        = mso_schema.test_schema.template_name
+  name                 = "Filter1"
+  display_name         = "Filter1"
+  entry_name           = "entry1"
+  entry_display_name   = "entry1"
+  entry_description    = "DemoEntry"
+  ether_type           = "arp"
+  ip_protocol          = "eigrp"
+  tcp_session_rules    = ["acknowledgement"]
+  destination_from     = "unspecified"
+  destination_to       = "unspecified"
+  source_from          = "unspecified"
+  source_to            = "unspecified"
+  arp_flag             = "unspecified"
+  stateful             = false
+  match_only_fragments = false
+}
+
+resource "mso_schema_template_contract" "template_contract" {
+  schema_id     = mso_schema.test_schema.id
+  template_name = mso_schema.test_schema.template_name
+  contract_name = "Contract1"
+  display_name  = "Contract1"
+  filter_type   = "bothWay"
+  scope         = "context"
+  filter_relationship {
+    filter_schema_id     = mso_schema_template_filter_entry.filter_entry.schema_id
+    filter_template_name = mso_schema_template_filter_entry.filter_entry.template_name
+    filter_name          = mso_schema_template_filter_entry.filter_entry.name
+  }
+  directives = ["none"]
+}
+
+resource "mso_schema_template_external_epg_contract" "consumer_contract" {
+  schema_id                 = mso_schema.test_schema.id
+  template_name             = mso_schema.test_schema.template_name
+  contract_name             = mso_schema_template_contract.template_contract.contract_name
+  external_epg_name         = mso_schema_template_external_epg.template_externalepg.external_epg_name
   relationship_type         = "consumer"
-  contract_schema_id        = "5ea809672c00003bc40a2799"
-  contract_template_name    = "Template1"
+  contract_schema_id        = mso_schema_template_contract.template_contract.schema_id
+  contract_template_name    = mso_schema_template_contract.template_contract.template_name
+}
+
+resource "mso_schema_template_external_epg_contract" "provider_contract" {
+  schema_id                 = mso_schema.test_schema.id
+  template_name             = mso_schema.test_schema.template_name
+  contract_name             = mso_schema_template_contract.template_contract.contract_name
+  external_epg_name         = mso_schema_template_external_epg.template_externalepg.external_epg_name
+  relationship_type         = "provider"
+  contract_schema_id        = mso_schema_template_contract.template_contract.schema_id
+  contract_template_name    = mso_schema_template_contract.template_contract.template_name
 }

--- a/examples/schema_template_external_epg_contract/main.tf
+++ b/examples/schema_template_external_epg_contract/main.tf
@@ -121,8 +121,3 @@ resource "mso_schema_template_external_epg_contract" "provider_contract_2" {
   contract_schema_id        = mso_schema_template_contract.template_contract_2.schema_id
   contract_template_name    = mso_schema_template_contract.template_contract_2.template_name
 }
-
-
-
-
-

--- a/examples/schema_template_external_epg_contract/main.tf
+++ b/examples/schema_template_external_epg_contract/main.tf
@@ -77,6 +77,21 @@ resource "mso_schema_template_contract" "template_contract" {
   directives = ["none"]
 }
 
+resource "mso_schema_template_contract" "template_contract_2" {
+  schema_id     = mso_schema.test_schema.id
+  template_name = mso_schema.test_schema.template_name
+  contract_name = "Contract2"
+  display_name  = "Contract2"
+  filter_type   = "bothWay"
+  scope         = "context"
+  filter_relationship {
+    filter_schema_id     = mso_schema_template_filter_entry.filter_entry.schema_id
+    filter_template_name = mso_schema_template_filter_entry.filter_entry.template_name
+    filter_name          = mso_schema_template_filter_entry.filter_entry.name
+  }
+  directives = ["none"]
+}
+
 resource "mso_schema_template_external_epg_contract" "consumer_contract" {
   schema_id                 = mso_schema.test_schema.id
   template_name             = mso_schema.test_schema.template_name
@@ -96,3 +111,18 @@ resource "mso_schema_template_external_epg_contract" "provider_contract" {
   contract_schema_id        = mso_schema_template_contract.template_contract.schema_id
   contract_template_name    = mso_schema_template_contract.template_contract.template_name
 }
+
+resource "mso_schema_template_external_epg_contract" "provider_contract_2" {
+  schema_id                 = mso_schema.test_schema.id
+  template_name             = mso_schema.test_schema.template_name
+  contract_name             = mso_schema_template_contract.template_contract_2.contract_name
+  external_epg_name         = mso_schema_template_external_epg.template_externalepg.external_epg_name
+  relationship_type         = "provider"
+  contract_schema_id        = mso_schema_template_contract.template_contract_2.schema_id
+  contract_template_name    = mso_schema_template_contract.template_contract_2.template_name
+}
+
+
+
+
+

--- a/mso/resource_mso_schema_template_external_epg_contract.go
+++ b/mso/resource_mso_schema_template_external_epg_contract.go
@@ -89,6 +89,7 @@ func resourceMSOTemplateExternalEpgContractImport(d *schema.ResourceData, m inte
 	found := false
 	stateEPG := get_attribute[4]
 	stateContract := get_attribute[6]
+	stateType := get_attribute[7]
 	for i := 0; i < count; i++ {
 		tempCont, err := cont.ArrayElement(i, "templates")
 		if err != nil {
@@ -122,12 +123,14 @@ func resourceMSOTemplateExternalEpgContractImport(d *schema.ResourceData, m inte
 						contractRef := models.StripQuotes(contractCont.S("contractRef").String())
 						re := regexp.MustCompile("/schemas/(.*)/templates/(.*)/contracts/(.*)")
 						split := re.FindStringSubmatch(contractRef)
-						if stateContract == (fmt.Sprintf("%s", split[3])) {
+						relationType := models.StripQuotes(contractCont.S("relationshipType").String())
+						if stateContract == (fmt.Sprintf("%s", split[3])) && stateType == relationType {
 							d.SetId(fmt.Sprintf("%s", split[3]))
 							d.Set("contract_name", fmt.Sprintf("%s", split[3]))
 							d.Set("contract_schema_id", fmt.Sprintf("%s", split[1]))
 							d.Set("contract_template_name", fmt.Sprintf("%s", split[2]))
 							d.Set("relationship_type", models.StripQuotes(contractCont.S("relationshipType").String()))
+							log.Printf("[relationType] %s : after set", d.Get("relationship_type"))
 							found = true
 							break
 						}
@@ -237,12 +240,13 @@ func resourceMSOTemplateExternalEpgContractRead(d *schema.ResourceData, m interf
 						contractRef := models.StripQuotes(contractCont.S("contractRef").String())
 						re := regexp.MustCompile("/schemas/(.*)/templates/(.*)/contracts/(.*)")
 						split := re.FindStringSubmatch(contractRef)
-						if stateContract == fmt.Sprintf("%s", split[3]) {
+						relationType := models.StripQuotes(contractCont.S("relationshipType").String())
+						if stateContract == fmt.Sprintf("%s", split[3]) && d.Get("relationship_type") == relationType {
 							d.SetId(fmt.Sprintf("%s", split[3]))
 							d.Set("contract_name", fmt.Sprintf("%s", split[3]))
 							d.Set("contract_schema_id", fmt.Sprintf("%s", split[1]))
 							d.Set("contract_template_name", fmt.Sprintf("%s", split[2]))
-							d.Set("relationship_type", models.StripQuotes(contractCont.S("relationshipType").String()))
+							d.Set("relationship_type", relationType)
 							found = true
 							break
 						}

--- a/website/docs/r/schema_template_external_epg_contract.html.markdown
+++ b/website/docs/r/schema_template_external_epg_contract.html.markdown
@@ -42,5 +42,5 @@ No attributes are exported.
 An existing MSO Schema Template External Endpoint Group Contract can be [imported][docs-import] into this resource via its Id/path, via the following command: [docs-import]: <https://www.terraform.io/docs/import/index.html>
 
 ```bash
-terraform import mso_schema_template_external_epg_contract.c1 {schema_id}/template/{template_name}/externalEPG/{external_epg_name}/contract/{contract_name}
+terraform import mso_schema_template_external_epg_contract.c1 {schema_id}/templates/{template_name}/externalEpgs/{external_epg_name}/contractRelationships/{contract_name}/{relationship_type}
 ```


### PR DESCRIPTION
- Add a check for contract type in order to fetch correct contractRelationships in resource mso_schema_template_external_epg_contract
- Set contractRef elements as forceNew
- Fix d.Id() to make it similar to patch path and contains contract type as well
- Update doc for terraform import path of mso_schema_template_external_epg_contract

resolve #108 