### PR TITLE
[bugfix] reset multi_destination_flooding to flood_in_bd while read/import template BD

### DIFF
--- a/examples/schema_template_bd/main.tf
+++ b/examples/schema_template_bd/main.tf
@@ -10,28 +10,51 @@ provider "mso" {
   username = "" # <MSO username>
   password = "" # <MSO pwd>
   url      = "" # <MSO URL>
+  # platform = "nd"
   insecure = true
 }
 
-resource "mso_schema_template_bd" "bridgedomain" {
-    schema_id              = "5c4d5bb72700000401f80948"
-    template_name          = "Temp200"
-    name                   = "testBD"
-    display_name           = "test"
-    vrf_name               = "vrf982"
-    vrf_schema_id          = "5c4d5bb72700000401f80948"
-    vrf_template_name      = "Temp200"
-    layer2_unknown_unicast = "proxy" 
-    intersite_bum_traffic  = false
-    optimize_wan_bandwidth = true
-    layer2_stretch         = true
-    layer3_multicast       = false
-    dhcp_policy = {
-        name = "Policy1"
-        version = 10
-        dhcp_option_policy_name = "Policy10"
-        dhcp_option_policy_version = 12
-    }
+resource "mso_tenant" "tenant_1" {
+  name         = "test_bd_tenant"
+  display_name = "test_bd_tenant"
+  description  = "DemoTenant"
+}
+
+resource "mso_schema" "schema_1" {
+  name          = "test_bd_schema"
+  template_name = "test_bd"
+  tenant_id     = mso_tenant.tenant_1.id
+}
+
+resource "mso_schema_template_vrf" "vrf" {
+  schema_id     = mso_schema.schema_1.id
+  template      = mso_schema.schema_1.template_name
+  name          = "test_bd_vrf"
+  display_name = "test_bd_vrf"
+}
+
+resource "mso_schema_template_bd" "bd" {
+  schema_id              = mso_schema.schema_1.id
+  template_name          = mso_schema.schema_1.template_name
+  name                   = "bd_demo"
+  display_name           = "bd_demo"
+  vrf_name               = mso_schema_template_vrf.vrf.name
+  vrf_schema_id          = mso_schema_template_vrf.vrf.schema_id
+  vrf_template_name      = mso_schema_template_vrf.vrf.template
+  layer2_unknown_unicast = "proxy"
+  intersite_bum_traffic  = false
+  optimize_wan_bandwidth = true
+  layer2_stretch         = true
+  layer3_multicast       = false
+  multi_destination_flooding = "flood_in_encap"
+  ipv6_unknown_multicast_flooding = "optimized_flooding"
+  unknown_multicast_flooding = "optimized_flooding"
+  dhcp_policy = {
+      name = "Policy1"
+      version = 10
+      dhcp_option_policy_name = "Policy10"
+      dhcp_option_policy_version = 12
+  }
 
   
 }

--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -177,7 +177,6 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[DEBUG] : Import getviaurl")
 	count, err := cont.ArrayCount("templates")
 	if err != nil {
 		return nil, fmt.Errorf("No Template found")
@@ -193,7 +192,6 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 		apiTemplate := models.StripQuotes(tempCont.S("name").String())
 
 		if apiTemplate == stateTemplate {
-			log.Printf("[DEBUG] : Import apiTemplate == stateTemplate")
 			bdCount, err := tempCont.ArrayCount("bds")
 			if err != nil {
 				return nil, fmt.Errorf("Unable to get BD list")
@@ -205,7 +203,6 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 				}
 				apiBD := models.StripQuotes(bdCont.S("name").String())
 				if apiBD == stateBD {
-					log.Printf("[DEBUG] : Import set attr")
 					d.SetId(apiBD)
 					d.Set("name", apiBD)
 					d.Set("schema_id", schemaId)
@@ -217,10 +214,7 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					} else {
 						d.Set("unknown_multicast_flooding", "flood")
 					}
-					log.Printf("[DEBUG] %s: Import Read unknown_mul_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
-					// d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
 					multiDstPktAct := models.StripQuotes(bdCont.S("multiDstPktAct").String())
-					log.Printf("[DEBUG] %s: Import Read multi_destination", multiDstPktAct)
 					if multiDstPktAct == "encap-flood" {
 						d.Set("multi_destination_flooding", "flood_in_encap")
 					} else if multiDstPktAct == "bd-flood" {
@@ -228,9 +222,7 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					} else {
 						d.Set("multi_destination_flooding", "drop")
 					}
-					// d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
 					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
-					log.Printf("[DEBUG] %s: Import Read ipv6_unknown_multicast_flooding", v6unkMcastAct)
 					if v6unkMcastAct == "opt-flood" {
 						d.Set("ipv6_unknown_multicast_flooding", "optimized_flooding")
 					} else {
@@ -452,14 +444,12 @@ func resourceMSOTemplateBDRead(d *schema.ResourceData, m interface{}) error {
 					d.Set("template_name", apiTemplate)
 					d.Set("display_name", models.StripQuotes(bdCont.S("displayName").String()))
 					d.Set("layer2_unknown_unicast", models.StripQuotes(bdCont.S("l2UnknownUnicast").String()))
-					log.Printf("[DEBUG] %s: Read unknown_mul_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
 					if models.StripQuotes(bdCont.S("unkMcastAct").String()) == "opt-flood" {
 						d.Set("unknown_multicast_flooding", "optimized_flooding")
 					} else {
 						d.Set("unknown_multicast_flooding", "flood")
 					}
 					multiDstPktAct := models.StripQuotes(bdCont.S("multiDstPktAct").String())
-					log.Printf("[DEBUG] %s: Read multi_destination", multiDstPktAct)
 					if multiDstPktAct == "encap-flood" {
 						d.Set("multi_destination_flooding", "flood_in_encap")
 					} else if multiDstPktAct == "bd-flood" {
@@ -468,15 +458,11 @@ func resourceMSOTemplateBDRead(d *schema.ResourceData, m interface{}) error {
 						d.Set("multi_destination_flooding", "drop")
 					}
 					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
-					log.Printf("[DEBUG] %s: Read ipv6_unknown_multicast_flooding", v6unkMcastAct)
 					if v6unkMcastAct == "opt-flood" {
 						d.Set("ipv6_unknown_multicast_flooding", "optimized_flooding")
 					} else {
 						d.Set("ipv6_unknown_multicast_flooding", "flood")
 					}
-					// d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
-					// d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
-					// d.Set("ipv6_unknown_multicast_flooding", models.StripQuotes(bdCont.S("v6unkMcastAct").String()))
 					d.Set("virtual_mac_address", models.StripQuotes(bdCont.S("vmac").String()))
 					if bdCont.Exists("intersiteBumTrafficAllow") {
 						d.Set("intersite_bum_traffic", bdCont.S("intersiteBumTrafficAllow").Data().(bool))

--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -226,9 +226,9 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					// d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
 					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
 					if v6unkMcastAct == "opt-flood" {
-						d.Set("multi_destination_flooding", "optimized_flooding")
+						d.Set("ipv6_unknown_multicast_flooding", "optimized_flooding")
 					} else {
-						d.Set("multi_destination_flooding", "flood")
+						d.Set("ipv6_unknown_multicast_flooding", "flood")
 					}
 					// d.Set("ipv6_unknown_multicast_flooding", models.StripQuotes(bdCont.S("v6unkMcastAct").String()))
 					d.Set("virtual_mac_address", models.StripQuotes(bdCont.S("vmac").String()))

--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -209,9 +209,28 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					d.Set("template_name", apiTemplate)
 					d.Set("display_name", models.StripQuotes(bdCont.S("displayName").String()))
 					d.Set("layer2_unknown_unicast", models.StripQuotes(bdCont.S("l2UnknownUnicast").String()))
-					d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
-					d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
-					d.Set("ipv6_unknown_multicast_flooding", models.StripQuotes(bdCont.S("v6unkMcastAct").String()))
+					if models.StripQuotes(bdCont.S("unkMcastAct").String()) == "opt-flood" {
+						d.Set("unknown_multicast_flooding", "optimized_flooding")
+					} else {
+						d.Set("unknown_multicast_flooding", "flood")
+					}
+					// d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
+					multiDstPktAct := models.StripQuotes(bdCont.S("multiDstPktAct").String())
+					if multiDstPktAct == "encap-flood" {
+						d.Set("multi_destination_flooding", "flood_in_encap")
+					} else if multiDstPktAct == "bd-flood" {
+						d.Set("multi_destination_flooding", "flood_in_bd")
+					} else {
+						d.Set("multi_destination_flooding", "drop")
+					}
+					// d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
+					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
+					if v6unkMcastAct == "opt-flood" {
+						d.Set("multi_destination_flooding", "optimized_flooding")
+					} else {
+						d.Set("multi_destination_flooding", "flood")
+					}
+					// d.Set("ipv6_unknown_multicast_flooding", models.StripQuotes(bdCont.S("v6unkMcastAct").String()))
 					d.Set("virtual_mac_address", models.StripQuotes(bdCont.S("vmac").String()))
 					if bdCont.Exists("intersiteBumTrafficAllow") {
 						d.Set("intersite_bum_traffic", bdCont.S("intersiteBumTrafficAllow").Data().(bool))
@@ -427,9 +446,28 @@ func resourceMSOTemplateBDRead(d *schema.ResourceData, m interface{}) error {
 					d.Set("template_name", apiTemplate)
 					d.Set("display_name", models.StripQuotes(bdCont.S("displayName").String()))
 					d.Set("layer2_unknown_unicast", models.StripQuotes(bdCont.S("l2UnknownUnicast").String()))
-					d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
-					d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
-					d.Set("ipv6_unknown_multicast_flooding", models.StripQuotes(bdCont.S("v6unkMcastAct").String()))
+					if models.StripQuotes(bdCont.S("unkMcastAct").String()) == "opt-flood" {
+						d.Set("unknown_multicast_flooding", "optimized_flooding")
+					} else {
+						d.Set("unknown_multicast_flooding", "flood")
+					}
+					multiDstPktAct := models.StripQuotes(bdCont.S("multiDstPktAct").String())
+					if multiDstPktAct == "encap-flood" {
+						d.Set("multi_destination_flooding", "flood_in_encap")
+					} else if multiDstPktAct == "bd-flood" {
+						d.Set("multi_destination_flooding", "flood_in_bd")
+					} else {
+						d.Set("multi_destination_flooding", "drop")
+					}
+					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
+					if v6unkMcastAct == "opt-flood" {
+						d.Set("multi_destination_flooding", "optimized_flooding")
+					} else {
+						d.Set("multi_destination_flooding", "flood")
+					}
+					// d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
+					// d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
+					// d.Set("ipv6_unknown_multicast_flooding", models.StripQuotes(bdCont.S("v6unkMcastAct").String()))
 					d.Set("virtual_mac_address", models.StripQuotes(bdCont.S("vmac").String()))
 					if bdCont.Exists("intersiteBumTrafficAllow") {
 						d.Set("intersite_bum_traffic", bdCont.S("intersiteBumTrafficAllow").Data().(bool))

--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -228,7 +228,6 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					} else {
 						d.Set("ipv6_unknown_multicast_flooding", "flood")
 					}
-					// d.Set("ipv6_unknown_multicast_flooding", models.StripQuotes(bdCont.S("v6unkMcastAct").String()))
 					d.Set("virtual_mac_address", models.StripQuotes(bdCont.S("vmac").String()))
 					if bdCont.Exists("intersiteBumTrafficAllow") {
 						d.Set("intersite_bum_traffic", bdCont.S("intersiteBumTrafficAllow").Data().(bool))

--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -177,6 +177,7 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("[DEBUG] : Import getviaurl")
 	count, err := cont.ArrayCount("templates")
 	if err != nil {
 		return nil, fmt.Errorf("No Template found")
@@ -192,6 +193,7 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 		apiTemplate := models.StripQuotes(tempCont.S("name").String())
 
 		if apiTemplate == stateTemplate {
+			log.Printf("[DEBUG] : Import apiTemplate == stateTemplate")
 			bdCount, err := tempCont.ArrayCount("bds")
 			if err != nil {
 				return nil, fmt.Errorf("Unable to get BD list")
@@ -203,6 +205,7 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 				}
 				apiBD := models.StripQuotes(bdCont.S("name").String())
 				if apiBD == stateBD {
+					log.Printf("[DEBUG] : Import set attr")
 					d.SetId(apiBD)
 					d.Set("name", apiBD)
 					d.Set("schema_id", schemaId)
@@ -214,8 +217,10 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					} else {
 						d.Set("unknown_multicast_flooding", "flood")
 					}
+					log.Printf("[DEBUG] %s: Import Read unknown_mul_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
 					// d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
 					multiDstPktAct := models.StripQuotes(bdCont.S("multiDstPktAct").String())
+					log.Printf("[DEBUG] %s: Import Read multi_destination", multiDstPktAct)
 					if multiDstPktAct == "encap-flood" {
 						d.Set("multi_destination_flooding", "flood_in_encap")
 					} else if multiDstPktAct == "bd-flood" {
@@ -225,6 +230,7 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					}
 					// d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))
 					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
+					log.Printf("[DEBUG] %s: Import Read ipv6_unknown_multicast_flooding", v6unkMcastAct)
 					if v6unkMcastAct == "opt-flood" {
 						d.Set("ipv6_unknown_multicast_flooding", "optimized_flooding")
 					} else {
@@ -446,12 +452,14 @@ func resourceMSOTemplateBDRead(d *schema.ResourceData, m interface{}) error {
 					d.Set("template_name", apiTemplate)
 					d.Set("display_name", models.StripQuotes(bdCont.S("displayName").String()))
 					d.Set("layer2_unknown_unicast", models.StripQuotes(bdCont.S("l2UnknownUnicast").String()))
+					log.Printf("[DEBUG] %s: Read unknown_mul_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
 					if models.StripQuotes(bdCont.S("unkMcastAct").String()) == "opt-flood" {
 						d.Set("unknown_multicast_flooding", "optimized_flooding")
 					} else {
 						d.Set("unknown_multicast_flooding", "flood")
 					}
 					multiDstPktAct := models.StripQuotes(bdCont.S("multiDstPktAct").String())
+					log.Printf("[DEBUG] %s: Read multi_destination", multiDstPktAct)
 					if multiDstPktAct == "encap-flood" {
 						d.Set("multi_destination_flooding", "flood_in_encap")
 					} else if multiDstPktAct == "bd-flood" {
@@ -460,6 +468,7 @@ func resourceMSOTemplateBDRead(d *schema.ResourceData, m interface{}) error {
 						d.Set("multi_destination_flooding", "drop")
 					}
 					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
+					log.Printf("[DEBUG] %s: Read ipv6_unknown_multicast_flooding", v6unkMcastAct)
 					if v6unkMcastAct == "opt-flood" {
 						d.Set("ipv6_unknown_multicast_flooding", "optimized_flooding")
 					} else {

--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -461,9 +461,9 @@ func resourceMSOTemplateBDRead(d *schema.ResourceData, m interface{}) error {
 					}
 					v6unkMcastAct := models.StripQuotes(bdCont.S("v6unkMcastAct").String())
 					if v6unkMcastAct == "opt-flood" {
-						d.Set("multi_destination_flooding", "optimized_flooding")
+						d.Set("ipv6_unknown_multicast_flooding", "optimized_flooding")
 					} else {
-						d.Set("multi_destination_flooding", "flood")
+						d.Set("ipv6_unknown_multicast_flooding", "flood")
 					}
 					// d.Set("unknown_multicast_flooding", models.StripQuotes(bdCont.S("unkMcastAct").String()))
 					// d.Set("multi_destination_flooding", models.StripQuotes(bdCont.S("multiDstPktAct").String()))


### PR DESCRIPTION
- reset multi_destination_flooding, unknown_multicast_flooding,  ipv6_unknown_multicast_flooding to what we use in UI while import/read from MSO
- update example for resource schema_template_bd

resolve #131 