### PR TITLE
Fixed empty VMAC for mso_schema_template_bd

### DIFF
--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -271,7 +271,7 @@ func resourceMSOTemplateBDImport(d *schema.ResourceData, m interface{}) ([]*sche
 					if vmac != "{}" {
 						d.Set("virtual_mac_address", vmac)
 					} else {
-						d.Set("virtual_mac_address", "")
+						d.Set("virtual_mac_address", nil)
 					}
 					if bdCont.Exists("intersiteBumTrafficAllow") {
 						d.Set("intersite_bum_traffic", bdCont.S("intersiteBumTrafficAllow").Data().(bool))


### PR DESCRIPTION
Related to issue https://github.com/CiscoDevNet/terraform-provider-mso/issues/163
It fixes BD creation on MSO 3.1.1n without specifying the virtual MAC address.
