### PR TITLE
Skip `mso_rest` delete if method set explicitly

### DIFF
--- a/mso/resource_mso_rest.go
+++ b/mso/resource_mso_rest.go
@@ -96,20 +96,17 @@ func resourceMSORestDelete(d *schema.ResourceData, m interface{}) error {
 	var method, path, payload string
 	path = d.Get("path").(string)
 	payload = d.Get("payload").(string)
-	if tempVar, ok := d.GetOk("method"); ok {
-		method = tempVar.(string)
-	} else {
+	
+	if tempVar, ok := d.GetOk("method"); !ok {
 		method = "DELETE"
+		msoClient := m.(*client.Client)
+		_, err := MakeRestRequest(msoClient, path, method, payload)
+	
+		if err != nil {
+			return err
+		}
 	}
-	if !contains(HTTP_METHODS, method) {
-		return fmt.Errorf("Invalid method %s passed", method)
-	}
-	msoClient := m.(*client.Client)
-	_, err := MakeRestRequest(msoClient, path, method, payload)
 
-	if err != nil {
-		return err
-	}
 	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
I don't see a single use-case where we would want to repeat a POST/PUT/PATCH/DELETE during destroy. If we absolutely want to retain backwards compatibility, alternatively it could also be implemented using an additional attribute/flag.