### PR TITLE
Else statement for fix 209

### DIFF
--- a/mso/resource_mso_schema_template_vrf.go
+++ b/mso/resource_mso_schema_template_vrf.go
@@ -189,7 +189,7 @@ func resourceMSOSchemaTemplateVrfCreate(d *schema.ResourceData, m interface{}) e
 	var ipDataPlaneLearning string
 	if ip_data_plane_learning, ok := d.GetOk("ip_data_plane_learning"); ok {
 		ipDataPlaneLearning = ip_data_plane_learning.(string)
-	}
+	} else {ipDataPlaneLearning = "enabled"}
 
 	var preferredGroup bool
 	if preferred_group, ok := d.GetOk("preferred_group"); ok {
@@ -247,7 +247,7 @@ func resourceMSOSchemaTemplateVrfUpdate(d *schema.ResourceData, m interface{}) e
 	var ipDataPlaneLearning string
 	if ip_data_plane_learning, ok := d.GetOk("ip_data_plane_learning"); ok {
 		ipDataPlaneLearning = ip_data_plane_learning.(string)
-	}
+	} else {ipDataPlaneLearning = "enabled"}
 
 	var preferredGroup bool
 	if preferred_group, ok := d.GetOk("preferred_group"); ok {


### PR DESCRIPTION
Related to #209 , as `ipDataPlaneLearning` and `preferredGroup` values are now being sent to  NDO, it expects a value for ipDataPlaneLearning, currently no value or "" is being sent, throwing an error. Preferred group defaults to "false" due to the Bool parsing, but `ipDataPlaneLearning` is a string, hense defaults to ""

As documented, the if the value is not set, then it should default to "enabled"

```
[ip_data_plane_learning](https://registry.terraform.io/providers/CiscoDevNet/mso/latest/docs/resources/schema_template_vrf#ip_data_plane_learning) - (Optional) Whether IP data plane learning is enabled or disabled. Allowed values are disabledand enabled. Default to enabled.
```

This faulty behaviour was introduced in #177 