### PR TITLE
Fix undeployment on destroy for resource mso_schema_site. (DCNE-55)

### DIFF
--- a/examples/schema_site/main.tf
+++ b/examples/schema_site/main.tf
@@ -50,9 +50,12 @@ resource "mso_tenant" "tenant_1" {
 }
 
 resource "mso_schema" "schema_1" {
-  name          = var.schema_name
-  template_name = var.template_name
-  tenant_id     = mso_tenant.tenant_1.id
+  name           = var.schema_name
+  template {
+    tenant_id    = mso_tenant.tenant_1.id
+    name         = var.template_name
+    display_name = var.template_name
+  }
 }
 
 resource "mso_schema_site" "schema_site_1" {
@@ -61,10 +64,10 @@ resource "mso_schema_site" "schema_site_1" {
   template_name = var.template_name
 }
 
-// when a template should be undeployed from site before disassociation the 'undeploy_on_delete' argument should be set to true prior to terraform destroy  
+// when a template should be undeployed from site before disassociation the 'undeploy_on_destroy' argument should be set to true prior to terraform destroy  
 resource "mso_schema_site" "schema_site_2" {
-  schema_id          = mso_schema.schema_1.id
-  site_id            = mso_site.site_test_1.id
-  template_name      = var.template_name
-  undeploy_on_delete = true
+  schema_id           = mso_schema.schema_1.id
+  site_id             = mso_site.site_test_1.id
+  template_name       = var.template_name
+  undeploy_on_destroy = true
 }

--- a/mso/resource_mso_schema_site.go
+++ b/mso/resource_mso_schema_site.go
@@ -205,31 +205,48 @@ func resourceMSOSchemaSiteDelete(d *schema.ResourceData, m interface{}) error {
 	siteId := d.Get("site_id").(string)
 	templateName := d.Get("template_name").(string)
 
-	versionInt, err := msoClient.CompareVersion("3.7.0.0")
-
-	if d.Get("undeploy_on_destroy").(bool) && versionInt == -1 {
-		payload, err := container.ParseJSON([]byte(fmt.Sprintf(`{"schemaId": "%s", "templateName": "%s", "undeploy": ["%s"]}`, schemaId, templateName, siteId)))
-		if err != nil {
-			log.Printf("[DEBUG] Parse of JSON failed with err: %s.", err)
-			return err
+	req, err := msoClient.MakeRestRequest("GET", fmt.Sprintf("api/v1/deploy/status/schema/%s/template/%s", schemaId, templateName), nil, true)
+	if err != nil {
+		log.Printf("[DEBUG] MakeRestRequest failed with err: %s.", err)
+		return err
+	}
+	obj, resp, err := msoClient.Do(req)
+	if err != nil || resp.StatusCode != 200 {
+		log.Printf("[DEBUG] Request failed with resp: %v. Err: %s.", resp, err)
+		return err
+	}
+	if deployMap, ok := obj.Data().(map[string]interface{}); ok {
+		if statusList, ok := deployMap["status"].([]map[string]interface{}); ok && len(statusList) > 0 {
+			for _, statusMap := range statusList {
+				if statusMap["siteId"] == siteId && statusMap["status"].(map[string]interface{})["siteStatus"] == "Succeeded" {
+					versionInt, err := msoClient.CompareVersion("3.7.0.0")
+					if d.Get("undeploy_on_destroy").(bool) && versionInt == -1 {
+						payload, err := container.ParseJSON([]byte(fmt.Sprintf(`{"schemaId": "%s", "templateName": "%s", "undeploy": ["%s"]}`, schemaId, templateName, siteId)))
+						if err != nil {
+							log.Printf("[DEBUG] Parse of JSON failed with err: %s.", err)
+							return err
+						}
+						req, err := msoClient.MakeRestRequest("POST", "api/v1/task", payload, true)
+						if err != nil {
+							log.Printf("[DEBUG] MakeRestRequest failed with err: %s.", err)
+							return err
+						}
+						_, resp, err := msoClient.Do(req)
+						if err != nil || resp.StatusCode != 202 {
+							log.Printf("[DEBUG] Request failed with resp: %v. Err: %s.", resp, err)
+							return err
+						}
+					} else if d.Get("undeploy_on_destroy").(bool) && err == nil {
+						_, err := msoClient.GetViaURL(fmt.Sprintf("/api/v1/execute/schema/%s/template/%s?undeploy=%s", schemaId, templateName, siteId))
+						if err != nil {
+							return err
+						}
+					} else if d.Get("undeploy_on_destroy").(bool) {
+						log.Printf("[WARNING] Failed to compare version. Template could not be undeployed prior to schema site deletion. Err: %s.", err)
+					}
+				}
+			}
 		}
-		req, err := msoClient.MakeRestRequest("POST", "api/v1/task", payload, true)
-		if err != nil {
-			log.Printf("[DEBUG] MakeRestRequest failed with err: %s.", err)
-			return err
-		}
-		_, resp, err := msoClient.Do(req)
-		if err != nil || resp.StatusCode != 202 {
-			log.Printf("[DEBUG] Request failed with resp: %v. Err: %s.", resp, err)
-			return err
-		}
-	} else if d.Get("undeploy_on_destroy").(bool) && err == nil {
-		_, err := msoClient.GetViaURL(fmt.Sprintf("/api/v1/execute/schema/%s/template/%s?undeploy=%s", schemaId, templateName, siteId))
-		if err != nil {
-			return err
-		}
-	} else if d.Get("undeploy_on_destroy").(bool) {
-		log.Printf("[WARNING] Failed to compare version. Template could not be undeployed prior to schema site deletion. Err: %s.", err)
 	}
 
 	schemasite := models.NewSchemaSite("remove", fmt.Sprintf("/sites/%s-%s", siteId, templateName), siteId, templateName)

--- a/mso/resource_mso_schema_site.go
+++ b/mso/resource_mso_schema_site.go
@@ -206,7 +206,7 @@ func resourceMSOSchemaSiteDelete(d *schema.ResourceData, m interface{}) error {
 	templateName := d.Get("template_name").(string)
 
 	if d.Get("undeploy_on_destroy").(bool) {
-		req, err := msoClient.MakeRestRequest("GET", fmt.Sprintf("mso/api/v1/deploy/status/schema/%s/template/%s", schemaId, templateName), nil, true)
+		req, err := msoClient.MakeRestRequest("GET", fmt.Sprintf("api/v1/deploy/status/schema/%s/template/%s", schemaId, templateName), nil, true)
 		if err != nil {
 			log.Printf("[DEBUG] MakeRestRequest failed with err: %s.", err)
 			return err
@@ -217,9 +217,9 @@ func resourceMSOSchemaSiteDelete(d *schema.ResourceData, m interface{}) error {
 			return err
 		}
 		if deployMap, ok := obj.Data().(map[string]interface{}); ok {
-			if statusList, ok := deployMap["status"].([]map[string]interface{}); ok && len(statusList) > 0 {
+			if statusList, ok := deployMap["status"].([]interface{}); ok && len(statusList) > 0 {
 				for _, statusMap := range statusList {
-					if statusMap["siteId"] == siteId && statusMap["status"].(map[string]interface{})["siteStatus"] == "Succeeded" {
+					if statusMap.(map[string]interface{})["siteId"] == siteId && statusMap.(map[string]interface{})["status"].(map[string]interface{})["siteStatus"] == "Succeeded" {
 						versionInt, err := msoClient.CompareVersion("3.7.0.0")
 						if versionInt == -1 {
 							payload, err := container.ParseJSON([]byte(fmt.Sprintf(`{"schemaId": "%s", "templateName": "%s", "undeploy": ["%s"]}`, schemaId, templateName, siteId)))


### PR DESCRIPTION
Fixes #287 

The Delete function will first check if template is deployed on site before being undeployed. If not deployed, It will now properly skip the undeployment phase which previously led to the resource being removed from State but not from MSO.