### PR TITLE
Add release PR feature to auto generate changelog entries. (DCNE-564)

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -1,0 +1,71 @@
+name: release_pr
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      
+      # git-cliff generates CHANGELOG.md
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install git-cliff==2.4.0 typos
+      - name: Check new changlog entry for version bump type
+        id: type
+        run: |
+          changelog=$(git cliff --unreleased)
+          case $changelog in
+              *"BREAKING CHANGES:"* )
+                  echo "MAJOR"
+                  echo "bump="MAJOR: version change"" >> $GITHUB_OUTPUT
+                  ;;
+              *"IMPROVEMENTS:"* )
+                  echo "MINOR"
+                  echo "bump="MINOR: version change"" >> $GITHUB_OUTPUT
+                  ;;
+              *"DEPRECATIONS:"* )
+                  echo "MINOR"
+                  echo "bump="MINOR: version change"" >> $GITHUB_OUTPUT
+                  ;;
+              * )
+                  echo "PATCH"
+                  echo "bump="PATCH: version change"" >> $GITHUB_OUTPUT
+                  ;;
+          esac
+      # The --with-commit inserts a commit message to git-cliff without it being in the history.
+      # It is used here to dynamically add version bump commands.
+      - name: Get next version
+        id: vars
+        run: echo "version=$(git cliff --bumped-version --with-commit "${{ steps.type.outputs.bump }}")" >> $GITHUB_OUTPUT
+      - name: Generate changelog output
+        run: git cliff --bump --unreleased --with-commit "${{ steps.type.outputs.bump }}"
+      - name: Prepend new changelog entry
+        run: git cliff --bump --unreleased -p CHANGELOG.md --with-commit "${{ steps.type.outputs.bump }}"
+
+      # Commit changes to release_pr branch
+      - name: Set git config
+        run: git config user.email "193842815+dcne-automation@users.noreply.github.com" && git config user.name "dcne-automation"
+      - name: Commit
+        run: git add -u && git status && git commit -m "[ignore] Update Changelog and annotation_unsupported.go for new release (${{ steps.vars.outputs.version }})"
+      - name: Branch & Push
+        run: git checkout -b release_pr && git push --set-upstream origin release_pr --force && git clean -f -d
+
+      # Create or update release PR
+      - run: gh pr create --base master --head release_pr --title "Pre-Release PR (${{ steps.vars.outputs.version }})" --body ""
+        id: pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.DCNE_AUTO_TOKEN }}
+      - run: gh pr edit release_pr --title "Pre-Release PR (${{ steps.vars.outputs.version }})"
+        if: steps.pr.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.DCNE_AUTO_TOKEN }}

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,6 @@
+[default.extend-words]
+# Don't correct the following words or acronyms
+aci = "aci"
+nd = "nd"
+mso = "mso"
+useg = "useg"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,67 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Terraform Provider MSO - Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+# TODO find a nicer way to remove the [something] tags from the start of commits.
+body = """
+{% if version %}\
+    ## {{ version | trim_start_matches(pat="v") }} ({{ timestamp | date(format="%B %d, %Y") }})
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    {{ group | striptags | trim | upper_first }}:
+    {% for commit in commits -%}
+        - {{ commit.message | trim 
+        | trim_start_matches(pat="[bugfix]") 
+        | trim_start_matches(pat="[bug_fix]") 
+        | trim_start_matches(pat="[bugfixes]") 
+        | trim_start_matches(pat="[minor_change]") 
+        | trim_start_matches(pat="[minor_changes]") 
+        | trim_start_matches(pat="[major_change]") 
+        | trim_start_matches(pat="[major_changes]") 
+        | trim | capitalize }}
+    {% endfor -%}
+{% endfor %}\n
+"""
+footer = """
+"""
+trim = true
+postprocessors = [
+  { pattern = '.*', replace_command = 'typos --write-changes -' }
+]
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = []
+commit_parsers = [
+  { message = "^.[I|i]gnore", skip = true },
+  { message = "^Bump", skip = true }, # Ignore Dependabot version bumps
+  { message = "^Merge.branch", skip = true }, # Ignore merge commits
+  { message = "^.[M|m]ajor", group = "<!-- 0 -->BREAKING CHANGES" },
+  { message = "[D|d]eprecat", group = "<!-- 1 -->DEPRECATIONS" },
+  { message = "^.[M|m]inor", group = "<!-- 2 -->IMPROVEMENTS" },
+  { message = "^.[B|b]ug", group = "<!-- 3 -->BUG FIXES" },
+  # Not skipped so version bumps are registered.
+  # However, not grouped so they don't show up in the changelog.
+  { message = ".*[MAJOR|MINOR|PATCH].*version change" },
+  { message = ".*", group = "<!-- 4 -->OTHER" },
+]
+protect_breaking_commits = false
+filter_commits = true
+topo_order = false
+sort_commits = "oldest"
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = true
+custom_major_increment_regex = "major"
+custom_minor_increment_regex = "minor"


### PR DESCRIPTION
Add the feature to auto generate changelog entries in a pre-release PR.
Existing functionality already exists in terraform-provider-aci.