### PR TITLE
Testing mso schema template vrf (DCNE-744)

### DIFF
--- a/mso/datasource_mso_schema_template_anp_epg_test.go
+++ b/mso/datasource_mso_schema_template_anp_epg_test.go
@@ -15,6 +15,11 @@ func TestAccMSOSchemaTemplateAnpEpgDatasource(t *testing.T) {
 		CheckDestroy: testAccCheckMSOSchemaTemplateAnpEpgDestroy,
 		Steps: []resource.TestStep{
 			{
+				PreConfig:   func() { fmt.Println("Test: Read EPG datasource not found error") },
+				Config:      testAccMSOSchemaTemplateAnpEpgDatasourceNotFound(),
+				ExpectError: regexp.MustCompile("Unable to find the ANP EPG"),
+			},
+			{
 				PreConfig: func() { fmt.Println("Test: Read EPG datasource") },
 				Config:    testAccMSOSchemaTemplateAnpEpgDatasource(),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -24,11 +29,6 @@ func TestAccMSOSchemaTemplateAnpEpgDatasource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.mso_schema_template_anp_epg.epg", "name", msoSchemaTemplateAnpEpgName),
 					resource.TestCheckResourceAttr("data.mso_schema_template_anp_epg.epg", "display_name", msoSchemaTemplateAnpEpgName),
 				),
-			},
-			{
-				PreConfig:   func() { fmt.Println("Test: Read EPG datasource not found error") },
-				Config:      testAccMSOSchemaTemplateAnpEpgDatasourceNotFound(),
-				ExpectError: regexp.MustCompile("Unable to find the ANP EPG"),
 			},
 		},
 	})

--- a/mso/datasource_mso_schema_template_anp_test.go
+++ b/mso/datasource_mso_schema_template_anp_test.go
@@ -15,6 +15,11 @@ func TestAccMSOSchemaTemplateAnpDatasource(t *testing.T) {
 		CheckDestroy: testAccCheckMSOSchemaTemplateAnpDestroy,
 		Steps: []resource.TestStep{
 			{
+				PreConfig:   func() { fmt.Println("Test: Read ANP datasource not found error") },
+				Config:      testAccMSOSchemaTemplateAnpDatasourceNotFound(),
+				ExpectError: regexp.MustCompile("Unable to find the ANP"),
+			},
+			{
 				PreConfig: func() { fmt.Println("Test: Read ANP datasource") },
 				Config:    testAccMSOSchemaTemplateAnpDatasource(),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -23,11 +28,6 @@ func TestAccMSOSchemaTemplateAnpDatasource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.mso_schema_template_anp.anp", "name", msoSchemaTemplateAnpName),
 					resource.TestCheckResourceAttr("data.mso_schema_template_anp.anp", "display_name", msoSchemaTemplateAnpName),
 				),
-			},
-			{
-				PreConfig:   func() { fmt.Println("Test: Read ANP datasource not found error") },
-				Config:      testAccMSOSchemaTemplateAnpDatasourceNotFound(),
-				ExpectError: regexp.MustCompile("Unable to find the ANP"),
 			},
 		},
 	})

--- a/mso/datasource_mso_schema_template_vrf.go
+++ b/mso/datasource_mso_schema_template_vrf.go
@@ -178,6 +178,7 @@ func datasourceMSOSchemaTemplateVrfRead(d *schema.ResourceData, m interface{}) e
 
 	if !found {
 		d.SetId("")
+		return fmt.Errorf("Unable to find the VRF %s in Template %s of Schema Id %s ", vrfName, templateName, schemaId)
 	}
 	log.Printf("[DEBUG] %s: Read finished successfully", d.Id())
 	return nil

--- a/mso/datasource_mso_schema_template_vrf_test.go
+++ b/mso/datasource_mso_schema_template_vrf_test.go
@@ -2,39 +2,81 @@ package mso
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccMSOSchemaTemplateVrfDataSource(t *testing.T) {
+func TestAccMSOSchemaTemplateVrfDatasource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMSOSchemaTemplateVrfDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() { fmt.Println("Test: Schema Template VRF Data Source") },
-				Config:    testAccMSOSchemaTemplateVrfDataSource(),
+				PreConfig:   func() { fmt.Println("Test: Read VRF datasource not found error") },
+				Config:      testAccMSOSchemaTemplateVrfDatasourceNotFound(),
+				ExpectError: regexp.MustCompile("Unable to find the VRF"),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Read VRF datasource") },
+				Config:    testAccMSOSchemaTemplateVrfDatasource(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "description", "Terraform test Schema Template VRF"),
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "display_name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "ip_data_plane_learning", "enabled"),
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "vzany", "false"),
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "preferred_group", "false"),
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "site_aware_policy_enforcement", "false"),
-					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.schema_template_vrf", "layer3_multicast", "false"),
+					resource.TestCheckResourceAttrSet("data.mso_schema_template_vrf.vrf", "schema_id"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "display_name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "description", "Terraform test VRF"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "ip_data_plane_learning", "enabled"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "vzany", "false"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "preferred_group", "false"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "site_aware_policy_enforcement", "false"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "layer3_multicast", "true"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_vrf.vrf", "rendezvous_points.#", "1"),
+					customTestCheckResourceTypeSetAttr("data.mso_schema_template_vrf.vrf", "rendezvous_points",
+						map[string]string{
+							"ip_address": "1.1.1.2",
+							"type":       "static",
+						},
+					),
 				),
 			},
 		},
 	})
 }
 
-func testAccMSOSchemaTemplateVrfDataSource() string {
+func testAccMSOSchemaTemplateVrfDatasourceConfig() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id        = mso_schema.%[3]s.id
+		template         = "%[4]s"
+		name             = "%[2]s"
+		display_name     = "%[2]s"
+		description      = "Terraform test VRF"
+		layer3_multicast = true
+		rendezvous_points {
+			ip_address                      = "1.1.1.2"
+			type                            = "static"
+			route_map_policy_multicast_uuid = mso_tenant_policies_route_map_policy_multicast.route_map_policy_multicast.uuid
+		}
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
+}
+
+func testAccMSOSchemaTemplateVrfDatasource() string {
 	return fmt.Sprintf(`%s
-	data "mso_schema_template_vrf" "schema_template_vrf" {
-		schema_id              = mso_schema_template_vrf.schema_template_vrf.schema_id
-		template               = mso_schema_template_vrf.schema_template_vrf.template
-		name                   = "tf_test_schema_template_vrf"
-	}`, testAccMSOSchemaTemplateVrfConfigCreate())
+	data "mso_schema_template_vrf" "vrf" {
+		schema_id = mso_schema.%[2]s.id
+		template  = "%[3]s"
+		name      = mso_schema_template_vrf.%[4]s.name
+	}`, testAccMSOSchemaTemplateVrfDatasourceConfig(), msoSchemaName, msoSchemaTemplateName, msoSchemaTemplateVrfName)
+}
+
+func testAccMSOSchemaTemplateVrfDatasourceNotFound() string {
+	return fmt.Sprintf(`%s
+	data "mso_schema_template_vrf" "vrf" {
+		schema_id = mso_schema.%[2]s.id
+		template  = "%[3]s"
+		name      = "non_existing_vrf_name"
+	}`, testAccMSOSchemaTemplateVrfDatasourceConfig(), msoSchemaName, msoSchemaTemplateName)
 }

--- a/mso/resource_mso_schema_template_vrf_test.go
+++ b/mso/resource_mso_schema_template_vrf_test.go
@@ -182,26 +182,40 @@ func TestAccMSOSchemaTemplateVrfResource(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() { fmt.Println("Test: Add BD child to VRF") },
-				Config:    testAccMSOSchemaTemplateVrfConfigWithBdChild(),
+				PreConfig: func() { fmt.Println("Test: Add BD and contract children to VRF") },
+				Config:    testAccMSOSchemaTemplateVrfConfigWithChildren(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
 					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
 					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
 					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "name", msoSchemaTemplateBdName),
 					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "display_name", msoSchemaTemplateBdName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf_contract."+msoSchemaTemplateContractName+"_provider", "contract_name", msoSchemaTemplateContractName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf_contract."+msoSchemaTemplateContractName+"_provider", "relationship_type", "provider"),
 				),
 			},
 			{
-				PreConfig: func() { fmt.Println("Test: Update VRF description with BD child present") },
-				Config:    testAccMSOSchemaTemplateVrfConfigWithBdChildUpdateDescription(),
+				PreConfig: func() { fmt.Println("Test: Update VRF description with children present") },
+				Config:    testAccMSOSchemaTemplateVrfConfigWithChildrenUpdateDescription(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
 					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
 					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", "Terraform test VRF with BD"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", "Terraform test VRF with children"),
 					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "name", msoSchemaTemplateBdName),
 					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "display_name", msoSchemaTemplateBdName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf_contract."+msoSchemaTemplateContractName+"_provider", "contract_name", msoSchemaTemplateContractName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf_contract."+msoSchemaTemplateContractName+"_provider", "relationship_type", "provider"),
+				),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Remove children from VRF") },
+				Config:    testAccMSOSchemaTemplateVrfConfigRemoveChildren(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", "Terraform test VRF with children"),
 				),
 			},
 		},
@@ -337,19 +351,34 @@ func testAccMSOSchemaTemplateVrfConfigRemoveAllRps() string {
 	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
 }
 
-func testAccMSOSchemaTemplateVrfConfigWithBdChild() string {
-	return testAccMSOSchemaTemplateVrfConfigUpdateDisplayName() + testSchemaTemplateBdConfig()
+func testAccMSOSchemaTemplateVrfChildrenConfig() string {
+	return testSchemaTemplateBdConfig() + testSchemaTemplateFilterEntryConfig() + testSchemaTemplateContractConfig() + testSchemaTemplateVrfContractConfig()
 }
 
-func testAccMSOSchemaTemplateVrfConfigWithBdChildUpdateDescription() string {
+func testAccMSOSchemaTemplateVrfConfigWithChildren() string {
+	return testAccMSOSchemaTemplateVrfConfigUpdateDisplayName() + testAccMSOSchemaTemplateVrfChildrenConfig()
+}
+
+func testAccMSOSchemaTemplateVrfConfigWithChildrenUpdateDescription() string {
 	return fmt.Sprintf(`%[1]s
 	resource "mso_schema_template_vrf" "%[2]s" {
 		schema_id    = mso_schema.%[3]s.id
 		template     = "%[4]s"
 		name         = "%[2]s"
 		display_name = "%[2]s updated"
-		description  = "Terraform test VRF with BD"
-	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName) + testSchemaTemplateBdConfig()
+		description  = "Terraform test VRF with children"
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName) + testAccMSOSchemaTemplateVrfChildrenConfig()
+}
+
+func testAccMSOSchemaTemplateVrfConfigRemoveChildren() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id    = mso_schema.%[3]s.id
+		template     = "%[4]s"
+		name         = "%[2]s"
+		display_name = "%[2]s updated"
+		description  = "Terraform test VRF with children"
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
 }
 
 func testAccCheckMSOSchemaTemplateVrfDestroy(s *terraform.State) error {

--- a/mso/resource_mso_schema_template_vrf_test.go
+++ b/mso/resource_mso_schema_template_vrf_test.go
@@ -4,42 +4,90 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ciscoecosystem/mso-go-client/client"
+	"github.com/ciscoecosystem/mso-go-client/models"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+// msoSchemaTemplateVrfSchemaId is set during the first test step's Check to capture the dynamic schema ID for use in the manual deletion PreConfig step.
+var msoSchemaTemplateVrfSchemaId string
 
 func TestAccMSOSchemaTemplateVrfResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMSOSchemaTemplateVrfDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() { fmt.Println("Test: Create Schema Template VRF") },
+				PreConfig: func() { fmt.Println("Test: Create VRF with name and display_name") },
 				Config:    testAccMSOSchemaTemplateVrfConfigCreate(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "description", "Terraform test Schema Template VRF"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "display_name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "ip_data_plane_learning", "enabled"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "vzany", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "preferred_group", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "site_aware_policy_enforcement", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "layer3_multicast", "false"),
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName),
+					// Capture the dynamic schema ID from state for use in the manual deletion PreConfig step
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["mso_schema_template_vrf."+msoSchemaTemplateVrfName]
+						if !ok {
+							return fmt.Errorf("VRF resource not found in state")
+						}
+						msoSchemaTemplateVrfSchemaId = rs.Primary.Attributes["schema_id"]
+						return nil
+					},
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", ""),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "layer3_multicast", "false"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "vzany", "false"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "preferred_group", "false"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "ip_data_plane_learning", "enabled"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "site_aware_policy_enforcement", "false"),
 				),
 			},
 			{
-				PreConfig: func() { fmt.Println("Test: Update Create Schema Template VRF by enabling Layer3 Multicast") },
-				Config:    testAccMSOSchemaTemplateVrfConfigUpdateEnablingLayer3Multicast(),
+				PreConfig: func() { fmt.Println("Test: Update VRF display_name") },
+				Config:    testAccMSOSchemaTemplateVrfConfigUpdateDisplayName(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "display_name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "ip_data_plane_learning", "enabled"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "description", "Terraform test Schema Template VRF with Layer3 Multicast"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "vzany", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "preferred_group", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "site_aware_policy_enforcement", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "layer3_multicast", "true"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points.#", "1"),
-					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points",
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", ""),
+				),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Add VRF description") },
+				Config:    testAccMSOSchemaTemplateVrfConfigAddDescription(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", "Terraform test VRF"),
+				),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Remove VRF description") },
+				Config:    testAccMSOSchemaTemplateVrfConfigRemoveDescription(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", ""),
+				),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Enable Layer3 Multicast and add RP") },
+				Config:    testAccMSOSchemaTemplateVrfConfigEnableLayer3Multicast(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "layer3_multicast", "true"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points.#", "1"),
+					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points",
 						map[string]string{
 							"ip_address": "1.1.1.2",
 							"type":       "static",
@@ -48,27 +96,22 @@ func TestAccMSOSchemaTemplateVrfResource(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {
-					fmt.Println("Test: Update Create Schema Template VRF by enabling Layer3 Multicast and adding an extra RP")
-				},
-				Config: testAccMSOSchemaTemplateVrfConfigUpdateAddingExtraRp(),
+				PreConfig: func() { fmt.Println("Test: Add extra RP") },
+				Config:    testAccMSOSchemaTemplateVrfConfigAddExtraRp(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "display_name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "ip_data_plane_learning", "enabled"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "description", "Terraform test Schema Template VRF with Layer3 Multicast"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "vzany", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "preferred_group", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "site_aware_policy_enforcement", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "layer3_multicast", "true"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points.#", "2"),
-					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points",
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "layer3_multicast", "true"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points.#", "2"),
+					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points",
 						map[string]string{
 							"ip_address": "1.1.1.2",
 							"type":       "static",
 						},
 					),
-					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points",
+					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points",
 						map[string]string{
 							"ip_address": "1.1.1.3",
 							"type":       "fabric",
@@ -77,21 +120,16 @@ func TestAccMSOSchemaTemplateVrfResource(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {
-					fmt.Println("Test: Update Create Schema Template VRF by enabling Layer3 Multicast and removing an extra RP")
-				},
-				Config: testAccMSOSchemaTemplateVrfConfigUpdateRemovingExtraRp(),
+				PreConfig: func() { fmt.Println("Test: Remove extra RP") },
+				Config:    testAccMSOSchemaTemplateVrfConfigRemoveExtraRp(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "display_name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "ip_data_plane_learning", "enabled"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "description", "Terraform test Schema Template VRF with Layer3 Multicast"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "vzany", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "preferred_group", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "site_aware_policy_enforcement", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "layer3_multicast", "true"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points.#", "1"),
-					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points",
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "layer3_multicast", "true"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points.#", "1"),
+					customTestCheckResourceTypeSetAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points",
 						map[string]string{
 							"ip_address": "1.1.1.2",
 							"type":       "static",
@@ -100,167 +138,255 @@ func TestAccMSOSchemaTemplateVrfResource(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {
-					fmt.Println("Test: Update Schema Template VRF by removing all RPs")
-				},
-				Config: testAccMSOSchemaTemplateVrfConfigUpdateRemoveAllRps(),
+				PreConfig: func() { fmt.Println("Test: Remove all RPs") },
+				Config:    testAccMSOSchemaTemplateVrfConfigRemoveAllRps(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "display_name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "ip_data_plane_learning", "enabled"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "description", "Terraform test Schema Template VRF with Layer3 Multicast"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "vzany", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "preferred_group", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "site_aware_policy_enforcement", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "layer3_multicast", "true"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "rendezvous_points.#", "0"),
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "template", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "layer3_multicast", "true"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "rendezvous_points.#", "0"),
 				),
 			},
 			{
-				PreConfig: func() {
-					fmt.Println("Test: Update Schema Template VRF by removing description")
+				PreConfig:    func() { fmt.Println("Test: Import VRF") },
+				ResourceName: "mso_schema_template_vrf." + msoSchemaTemplateVrfName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["mso_schema_template_vrf."+msoSchemaTemplateVrfName]
+					if !ok {
+						return "", fmt.Errorf("VRF resource not found in state")
+					}
+					return fmt.Sprintf("%s/templates/%s/vrfs/%s", rs.Primary.Attributes["schema_id"], rs.Primary.Attributes["template"], rs.Primary.Attributes["name"]), nil
 				},
-				Config: testAccMSOSchemaTemplateVrfConfigUpdateRemoveDescription(),
+				ImportStateVerify: true,
+				// Description attribute is set to empty string on import but it is not provided in the config.
+				ImportStateVerifyIgnore: []string{"description"},
+			},
+			{
+				PreConfig: func() {
+					fmt.Println("Test: Recreate VRF after manual deletion from NDO")
+					msoClient := testAccProvider.Meta().(*client.Client)
+					vrfRemovePatchPayload := models.GetRemovePatchPayload(fmt.Sprintf("/templates/%s/vrfs/%s", msoSchemaTemplateName, msoSchemaTemplateVrfName))
+					_, err := msoClient.PatchbyID(fmt.Sprintf("api/v1/schemas/%s", msoSchemaTemplateVrfSchemaId), vrfRemovePatchPayload)
+					if err != nil {
+						t.Fatalf("Failed to manually delete VRF: %v", err)
+					}
+				},
+				Config: testAccMSOSchemaTemplateVrfConfigRemoveAllRps(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "display_name", "tf_test_schema_template_vrf"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "description", ""),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "ip_data_plane_learning", "enabled"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "vzany", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "preferred_group", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "site_aware_policy_enforcement", "false"),
-					resource.TestCheckResourceAttr("mso_schema_template_vrf.schema_template_vrf", "layer3_multicast", "true"),
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+				),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Add BD child to VRF") },
+				Config:    testAccMSOSchemaTemplateVrfConfigWithBdChild(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "name", msoSchemaTemplateBdName),
+					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "display_name", msoSchemaTemplateBdName),
+				),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Update VRF description with BD child present") },
+				Config:    testAccMSOSchemaTemplateVrfConfigWithBdChildUpdateDescription(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "name", msoSchemaTemplateVrfName),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "display_name", msoSchemaTemplateVrfName+" updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_vrf."+msoSchemaTemplateVrfName, "description", "Terraform test VRF with BD"),
+					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "name", msoSchemaTemplateBdName),
+					resource.TestCheckResourceAttr("mso_schema_template_bd."+msoSchemaTemplateBdName, "display_name", msoSchemaTemplateBdName),
 				),
 			},
 		},
-		CheckDestroy: testCheckResourceDestroyPolicyWithArguments("mso_schema_template_vrf", "vrf"),
 	})
 }
 
-func testAccMSOSchemaTemplateForVrfConfig() string {
-	return fmt.Sprintf(`%s
-	resource "mso_schema" "schema_for_vrf" {
-		name = "tf_test_schema_for_vrf"
-		template {
-			name         = "tf_test_schema_template"
-			display_name = "tf_test_schema_template"
-			tenant_id    = mso_tenant.%s.id
-			template_type = "aci_multi_site"
+func testAccMSOSchemaTemplateVrfRouteMapPolicyMulticastConfig() string {
+	return fmt.Sprintf(`
+	resource "mso_tenant_policies_route_map_policy_multicast" "route_map_policy_multicast" {
+		template_id = mso_template.%[1]s.id
+		name        = "tf_test_route_map_policy_multicast"
+		description = "Terraform test Route Map Policy for Multicast"
+		route_map_multicast_entries {
+			order               = 1
+			group_ip            = "226.2.2.2/8"
+			source_ip           = "1.1.1.1/1"
+			rendezvous_point_ip = "1.1.1.2"
+			action              = "permit"
 		}
-} `, testAccMSOTenantPoliciesMcastRouteMapPolicyConfigCreate(), msoTemplateTenantName)
+	}`, msoTenantPolicyTemplateName)
+}
+
+func testAccMSOSchemaTemplateVrfPrerequisiteConfig() string {
+	return fmt.Sprintf(`%s%s%s%s%s`, testSiteConfigAnsibleTest(), testTenantConfig(), testSchemaConfig(), testTenantPolicyTemplateConfig(), testAccMSOSchemaTemplateVrfRouteMapPolicyMulticastConfig())
 }
 
 func testAccMSOSchemaTemplateVrfConfigCreate() string {
-	return fmt.Sprintf(`%s
-	resource "mso_schema_template_vrf" "schema_template_vrf" {
-		schema_id                     = mso_schema.schema_for_vrf.id
-		template                      = tolist(mso_schema.schema_for_vrf.template)[0].name
-		name                          = "tf_test_schema_template_vrf"
-		display_name                  = "tf_test_schema_template_vrf"
-		description                   = "Terraform test Schema Template VRF"
-		ip_data_plane_learning        = "enabled"
-		vzany                         = false
-		preferred_group               = false
-		site_aware_policy_enforcement = false
-		layer3_multicast              = false
-	}`, testAccMSOSchemaTemplateForVrfConfig())
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id    = mso_schema.%[3]s.id
+		template     = "%[4]s"
+		name         = "%[2]s"
+		display_name = "%[2]s"
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
 }
 
-func testAccMSOSchemaTemplateVrfConfigUpdateEnablingLayer3Multicast() string {
-	return fmt.Sprintf(`%s
-	resource "mso_schema_template_vrf" "schema_template_vrf" {
-		schema_id                     = mso_schema.schema_for_vrf.id
-		template                      = tolist(mso_schema.schema_for_vrf.template)[0].name
-		name                          = "tf_test_schema_template_vrf"
-		display_name                  = "tf_test_schema_template_vrf"
-		description                   = "Terraform test Schema Template VRF with Layer3 Multicast"
-		ip_data_plane_learning        = "enabled"
-		vzany                         = false
-		preferred_group               = false
-		site_aware_policy_enforcement = false
-		layer3_multicast              = true
+func testAccMSOSchemaTemplateVrfConfigUpdateDisplayName() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id    = mso_schema.%[3]s.id
+		template     = "%[4]s"
+		name         = "%[2]s"
+		display_name = "%[2]s updated"
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
+}
+
+func testAccMSOSchemaTemplateVrfConfigAddDescription() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id    = mso_schema.%[3]s.id
+		template     = "%[4]s"
+		name         = "%[2]s"
+		display_name = "%[2]s updated"
+		description  = "Terraform test VRF"
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
+}
+
+func testAccMSOSchemaTemplateVrfConfigRemoveDescription() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id    = mso_schema.%[3]s.id
+		template     = "%[4]s"
+		name         = "%[2]s"
+		display_name = "%[2]s updated"
+		description  = ""
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
+}
+
+func testAccMSOSchemaTemplateVrfConfigEnableLayer3Multicast() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id        = mso_schema.%[3]s.id
+		template         = "%[4]s"
+		name             = "%[2]s"
+		display_name     = "%[2]s updated"
+		description      = ""
+		layer3_multicast = true
 		rendezvous_points {
 			ip_address                      = "1.1.1.2"
 			type                            = "static"
 			route_map_policy_multicast_uuid = mso_tenant_policies_route_map_policy_multicast.route_map_policy_multicast.uuid
 		}
-	}`, testAccMSOSchemaTemplateForVrfConfig())
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
 }
 
-func testAccMSOSchemaTemplateVrfConfigUpdateAddingExtraRp() string {
-	return fmt.Sprintf(`%s
-	resource "mso_schema_template_vrf" "schema_template_vrf" {
-		schema_id                     = mso_schema.schema_for_vrf.id
-		template                      = tolist(mso_schema.schema_for_vrf.template)[0].name
-		name                          = "tf_test_schema_template_vrf"
-		display_name                  = "tf_test_schema_template_vrf"
-		description                   = "Terraform test Schema Template VRF with Layer3 Multicast"
-		ip_data_plane_learning        = "enabled"
-		vzany                         = false
-		preferred_group               = false
-		site_aware_policy_enforcement = false
-		layer3_multicast              = true
+func testAccMSOSchemaTemplateVrfConfigAddExtraRp() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id        = mso_schema.%[3]s.id
+		template         = "%[4]s"
+		name             = "%[2]s"
+		display_name     = "%[2]s updated"
+		description      = ""
+		layer3_multicast = true
 		rendezvous_points {
 			ip_address                      = "1.1.1.2"
 			type                            = "static"
 			route_map_policy_multicast_uuid = mso_tenant_policies_route_map_policy_multicast.route_map_policy_multicast.uuid
 		}
 		rendezvous_points {
-			ip_address                      = "1.1.1.3"
-			type                            = "fabric"
+			ip_address = "1.1.1.3"
+			type       = "fabric"
 		}
-	}`, testAccMSOSchemaTemplateForVrfConfig())
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
 }
 
-func testAccMSOSchemaTemplateVrfConfigUpdateRemovingExtraRp() string {
-	return fmt.Sprintf(`%s
-	resource "mso_schema_template_vrf" "schema_template_vrf" {
-		schema_id                     = mso_schema.schema_for_vrf.id
-		template                      = tolist(mso_schema.schema_for_vrf.template)[0].name
-		name                          = "tf_test_schema_template_vrf"
-		display_name                  = "tf_test_schema_template_vrf"
-		description                   = "Terraform test Schema Template VRF with Layer3 Multicast"
-		ip_data_plane_learning        = "enabled"
-		vzany                         = false
-		preferred_group               = false
-		site_aware_policy_enforcement = false
-		layer3_multicast              = true
+func testAccMSOSchemaTemplateVrfConfigRemoveExtraRp() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id        = mso_schema.%[3]s.id
+		template         = "%[4]s"
+		name             = "%[2]s"
+		display_name     = "%[2]s updated"
+		description      = ""
+		layer3_multicast = true
 		rendezvous_points {
 			ip_address                      = "1.1.1.2"
 			type                            = "static"
 			route_map_policy_multicast_uuid = mso_tenant_policies_route_map_policy_multicast.route_map_policy_multicast.uuid
 		}
-	}`, testAccMSOSchemaTemplateForVrfConfig())
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
 }
 
-func testAccMSOSchemaTemplateVrfConfigUpdateRemoveAllRps() string {
-	return fmt.Sprintf(`%s
-	resource "mso_schema_template_vrf" "schema_template_vrf" {
-		schema_id                     = mso_schema.schema_for_vrf.id
-		template                      = tolist(mso_schema.schema_for_vrf.template)[0].name
-		name                          = "tf_test_schema_template_vrf"
-		display_name                  = "tf_test_schema_template_vrf"
-		description                   = "Terraform test Schema Template VRF with Layer3 Multicast"
-		ip_data_plane_learning        = "enabled"
-		vzany                         = false
-		preferred_group               = false
-		site_aware_policy_enforcement = false
-		layer3_multicast              = true
-	}`, testAccMSOSchemaTemplateForVrfConfig())
+func testAccMSOSchemaTemplateVrfConfigRemoveAllRps() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id        = mso_schema.%[3]s.id
+		template         = "%[4]s"
+		name             = "%[2]s"
+		display_name     = "%[2]s updated"
+		description      = ""
+		layer3_multicast = true
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName)
 }
 
-func testAccMSOSchemaTemplateVrfConfigUpdateRemoveDescription() string {
-	return fmt.Sprintf(`%s
-	resource "mso_schema_template_vrf" "schema_template_vrf" {
-		schema_id                     = mso_schema.schema_for_vrf.id
-		template                      = tolist(mso_schema.schema_for_vrf.template)[0].name
-		name                          = "tf_test_schema_template_vrf"
-		display_name                  = "tf_test_schema_template_vrf"
-		description                   = ""
-		ip_data_plane_learning        = "enabled"
-		vzany                         = false
-		preferred_group               = false
-		site_aware_policy_enforcement = false
-		layer3_multicast              = true
-	}`, testAccMSOSchemaTemplateForVrfConfig())
+func testAccMSOSchemaTemplateVrfConfigWithBdChild() string {
+	return testAccMSOSchemaTemplateVrfConfigUpdateDisplayName() + testSchemaTemplateBdConfig()
+}
+
+func testAccMSOSchemaTemplateVrfConfigWithBdChildUpdateDescription() string {
+	return fmt.Sprintf(`%[1]s
+	resource "mso_schema_template_vrf" "%[2]s" {
+		schema_id    = mso_schema.%[3]s.id
+		template     = "%[4]s"
+		name         = "%[2]s"
+		display_name = "%[2]s updated"
+		description  = "Terraform test VRF with BD"
+	}`, testAccMSOSchemaTemplateVrfPrerequisiteConfig(), msoSchemaTemplateVrfName, msoSchemaName, msoSchemaTemplateName) + testSchemaTemplateBdConfig()
+}
+
+func testAccCheckMSOSchemaTemplateVrfDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*client.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "mso_schema_template_vrf" {
+			schemaID := rs.Primary.Attributes["schema_id"]
+			con, err := client.GetViaURL(fmt.Sprintf("api/v1/schemas/%s", schemaID))
+			if err != nil {
+				return nil
+			}
+			count, err := con.ArrayCount("templates")
+			if err != nil {
+				return fmt.Errorf("No Template found")
+			}
+			for i := 0; i < count; i++ {
+				tempCont, err := con.ArrayElement(i, "templates")
+				if err != nil {
+					return fmt.Errorf("No template exists")
+				}
+				vrfCount, err := tempCont.ArrayCount("vrfs")
+				if err != nil {
+					return fmt.Errorf("No Vrf found")
+				}
+				for j := 0; j < vrfCount; j++ {
+					vrfCont, err := tempCont.ArrayElement(j, "vrfs")
+					if err != nil {
+						return err
+					}
+					name := models.StripQuotes(vrfCont.S("name").String())
+					if rs.Primary.ID == name {
+						return fmt.Errorf("Schema Template Vrf record still exists")
+					}
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/mso/test_constants.go
+++ b/mso/test_constants.go
@@ -266,6 +266,18 @@ resource "mso_schema_template_contract" "%[1]s" {
 `, msoSchemaTemplateContractName, msoSchemaName, msoSchemaTemplateName, msoSchemaTemplateFilterName)
 }
 
+func testSchemaTemplateVrfContractConfig() string {
+	return fmt.Sprintf(`
+resource "mso_schema_template_vrf_contract" "%[1]s_provider" {
+	schema_id         = mso_schema.%[2]s.id
+	template_name     = "%[3]s"
+	vrf_name          = mso_schema_template_vrf.%[4]s.name
+	relationship_type = "provider"
+	contract_name     = mso_schema_template_contract.%[1]s.contract_name
+}
+`, msoSchemaTemplateContractName, msoSchemaName, msoSchemaTemplateName, msoSchemaTemplateVrfName)
+}
+
 func testSchemaTemplateAnpEpgContractConfig() string {
 	return fmt.Sprintf(`
 resource "mso_schema_template_anp_epg_contract" "%[1]s_provider" {


### PR DESCRIPTION
changed the order of the datasource not found test because ending with an error that is asserted correctly does not remove the configuration