### PR TITLE
[ignore] Fix CustomTestCheckTypeSetElemAttrs to resolve reference values for comparison (DCNE-823 DCNE-822)

### DIFF
--- a/mso/datasource_mso_service_device_cluster_test.go
+++ b/mso/datasource_mso_service_device_cluster_test.go
@@ -28,8 +28,7 @@ func TestAccMSOServiceDeviceClusterDataSource(t *testing.T) {
 						"threshold_down_action": "permit",
 					}),
 					CustomTestCheckTypeSetElemAttrs("data.mso_service_device_cluster.cluster", "interface_properties", map[string]string{
-						"name":    "interface3",
-						"anycast": "true",
+						"name": "interface3",
 					}),
 				),
 			},

--- a/mso/datasource_mso_tenant_policies_dhcp_relay_policy_test.go
+++ b/mso/datasource_mso_tenant_policies_dhcp_relay_policy_test.go
@@ -22,7 +22,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "description", ""),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "template_id"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers.#", "2"),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       fmt.Sprintf("mso_schema_template_anp_epg.%s.uuid", msoSchemaTemplateAnpEpgName),
 							"dhcp_server_address":        "1.1.1.1",
@@ -30,7 +30,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyDataSource(t *testing.T) {
 							"external_epg_uuid":          "",
 						},
 					),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       "",
 							"dhcp_server_address":        "2.2.2.2",

--- a/mso/provider_test.go
+++ b/mso/provider_test.go
@@ -195,12 +195,37 @@ func customTestCheckResourceTypeSetAttr(resourceName, resourceAttrRootkey string
 	}
 }
 
+// resolveStateReference resolves a value that looks like a Terraform resource reference
+// (e.g. "resource_type.resource_name.attribute") by looking up the actual value in state.
+// If the value does not match this pattern or the referenced resource/attribute is not found,
+// the original value is returned unchanged.
+func resolveStateReference(s *terraform.State, value string) string {
+	parts := strings.SplitN(value, ".", 3)
+	if len(parts) != 3 {
+		return value
+	}
+	resourceKey := parts[0] + "." + parts[1]
+	attrName := parts[2]
+	if rs, ok := s.RootModule().Resources[resourceKey]; ok {
+		if attrVal, ok := rs.Primary.Attributes[attrName]; ok {
+			return attrVal
+		}
+	}
+	return value
+}
+
 func CustomTestCheckTypeSetElemAttrs(resourceName, setName string, attrsToCheck map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Resource not found: %s", resourceName)
 		}
+
+		resolvedAttrs := make(map[string]string, len(attrsToCheck))
+		for k, v := range attrsToCheck {
+			resolvedAttrs[k] = resolveStateReference(s, v)
+		}
+
 		groupedAttrs := make(map[string]map[string]string)
 		re := regexp.MustCompile(fmt.Sprintf(`^%s\.(\d+)\.(.*)$`, setName))
 
@@ -218,7 +243,7 @@ func CustomTestCheckTypeSetElemAttrs(resourceName, setName string, attrsToCheck 
 
 		for _, elemAttrs := range groupedAttrs {
 			match := true
-			for expectedKey, expectedVal := range attrsToCheck {
+			for expectedKey, expectedVal := range resolvedAttrs {
 				if val, ok := elemAttrs[expectedKey]; ok {
 					if fmt.Sprintf("%v", val) != expectedVal {
 						match = false

--- a/mso/resource_mso_tenant_policies_dhcp_relay_policy_test.go
+++ b/mso/resource_mso_tenant_policies_dhcp_relay_policy_test.go
@@ -36,7 +36,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "description", ""),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "template_id"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers.#", "2"),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       fmt.Sprintf("mso_schema_template_anp_epg.%s.uuid", msoSchemaTemplateAnpEpgName),
 							"dhcp_server_address":        "1.1.1.1",
@@ -44,7 +44,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyResource(t *testing.T) {
 							"external_epg_uuid":          "",
 						},
 					),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       "",
 							"dhcp_server_address":        "2.2.2.2",
@@ -69,7 +69,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "description", "Updated DHCP Relay Policy"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "template_id"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers.#", "2"),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       fmt.Sprintf("mso_schema_template_anp_epg.%s.uuid", msoSchemaTemplateAnpEpgName),
 							"dhcp_server_address":        "1.1.1.1",
@@ -77,7 +77,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyResource(t *testing.T) {
 							"external_epg_uuid":          "",
 						},
 					),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       "",
 							"dhcp_server_address":        "2.2.2.2",
@@ -95,7 +95,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "description", "Updated DHCP Relay Policy"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "template_id"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers.#", "1"),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       fmt.Sprintf("mso_schema_template_anp_epg.%s.uuid", msoSchemaTemplateAnpEpgName),
 							"dhcp_server_address":        "1.1.1.1",
@@ -113,7 +113,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "description", "Updated DHCP Relay Policy"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "template_id"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers.#", "2"),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       fmt.Sprintf("mso_schema_template_anp_epg.%s.uuid", msoSchemaTemplateAnpEpgName),
 							"dhcp_server_address":        "1.1.1.2",
@@ -121,7 +121,7 @@ func TestAccMSOTenantPoliciesDHCPRelayPolicyResource(t *testing.T) {
 							"external_epg_uuid":          "",
 						},
 					),
-					customTestCheckResourceTypeSetAttr(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
+					CustomTestCheckTypeSetElemAttrs(fmt.Sprintf("mso_tenant_policies_dhcp_relay_policy.%s", name), "dhcp_relay_providers",
 						map[string]string{
 							"application_epg_uuid":       "",
 							"dhcp_server_address":        "2.2.2.2",


### PR DESCRIPTION
This fixes ipsla track list tests.
I also updated the dhcp relay tests to validate the fix.
It also fixes an extra test assertion in datasource_mso_service_device_cluster_test.