### PR TITLE
[ignore] Fix mso_tenant_policies_igmp_interface_policy tests for ND 4.2 (DCNE-831)

### DIFF
--- a/mso/datasource_mso_tenant_policies_igmp_interface_policy_test.go
+++ b/mso/datasource_mso_tenant_policies_igmp_interface_policy_test.go
@@ -45,19 +45,6 @@ func TestAccMSOTenantPoliciesIGMPInterfacePolicyDataSource(t *testing.T) {
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyDataSource() string {
 	return fmt.Sprintf(`%s
-    resource "mso_tenant_policies_route_map_policy_multicast" "static_report" {
-        template_id = mso_template.template_tenant.id
-        name        = "test_static_report_route_map"
-        description = "Static Report Route Map for IGMP"
-		route_map_multicast_entries {
-			order                   = 1
-			group_ip                = "226.2.2.2/8"
-			source_ip               = "1.1.1.1/1"
-			rendezvous_point_ip     = "1.1.1.2"
-			action                  = "permit"
-		}
-    }
-
     resource "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
         template_id                    = mso_template.template_tenant.id
         name                           = "test_igmp_interface_policy_max"
@@ -77,12 +64,12 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyDataSource() string {
         robustness_variable            = 7
         maximum_multicast_entries      = 4294967295
         reserved_multicast_entries     = 4294967295
-        state_limit_route_map_uuid     = mso_tenant_policies_route_map_policy_multicast.static_report.uuid
+        state_limit_route_map_uuid     = mso_tenant_policies_route_map_policy_multicast.state_limit.uuid
         static_report_route_map_uuid   = mso_tenant_policies_route_map_policy_multicast.static_report.uuid
     }
 
     data "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
         template_id = mso_template.template_tenant.id
         name        = mso_tenant_policies_igmp_interface_policy.igmp_policy.name
-    }`, testAccMSOTemplateResourceTenantConfig())
+    }`, fmt.Sprintf("%s%s", testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPAllRouteMapsConfig()))
 }

--- a/mso/datasource_mso_tenant_policies_igmp_interface_policy_test.go
+++ b/mso/datasource_mso_tenant_policies_igmp_interface_policy_test.go
@@ -36,6 +36,7 @@ func TestAccMSOTenantPoliciesIGMPInterfacePolicyDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.mso_tenant_policies_igmp_interface_policy.igmp_policy", "maximum_multicast_entries", "4294967295"),
 					resource.TestCheckResourceAttr("data.mso_tenant_policies_igmp_interface_policy.igmp_policy", "reserved_multicast_entries", "4294967295"),
 					resource.TestCheckResourceAttrSet("data.mso_tenant_policies_igmp_interface_policy.igmp_policy", "static_report_route_map_uuid"),
+					resource.TestCheckResourceAttrSet("data.mso_tenant_policies_igmp_interface_policy.igmp_policy", "state_limit_route_map_uuid"),
 				),
 			},
 		},
@@ -76,6 +77,7 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyDataSource() string {
         robustness_variable            = 7
         maximum_multicast_entries      = 4294967295
         reserved_multicast_entries     = 4294967295
+        state_limit_route_map_uuid     = mso_tenant_policies_route_map_policy_multicast.static_report.uuid
         static_report_route_map_uuid   = mso_tenant_policies_route_map_policy_multicast.static_report.uuid
     }
 

--- a/mso/resource_mso_tenant_policies_igmp_interface_policy_test.go
+++ b/mso/resource_mso_tenant_policies_igmp_interface_policy_test.go
@@ -34,6 +34,7 @@ func TestAccMSOTenantPoliciesIGMPInterfacePolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr("mso_tenant_policies_igmp_interface_policy.igmp_policy", "robustness_variable", "2"),
 					resource.TestCheckResourceAttr("mso_tenant_policies_igmp_interface_policy.igmp_policy", "maximum_multicast_entries", "1000000"),
 					resource.TestCheckResourceAttr("mso_tenant_policies_igmp_interface_policy.igmp_policy", "reserved_multicast_entries", "100000"),
+					resource.TestCheckResourceAttrSet("mso_tenant_policies_igmp_interface_policy.igmp_policy", "state_limit_route_map_uuid"),
 				),
 			},
 			{
@@ -102,6 +103,7 @@ func TestAccMSOTenantPoliciesIGMPInterfacePolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr("mso_tenant_policies_igmp_interface_policy.igmp_policy", "robustness_variable", "7"),
 					resource.TestCheckResourceAttr("mso_tenant_policies_igmp_interface_policy.igmp_policy", "maximum_multicast_entries", "4294967295"),
 					resource.TestCheckResourceAttr("mso_tenant_policies_igmp_interface_policy.igmp_policy", "reserved_multicast_entries", "4294967295"),
+					resource.TestCheckResourceAttrSet("mso_tenant_policies_igmp_interface_policy.igmp_policy", "state_limit_route_map_uuid"),
 				),
 			},
 			{
@@ -141,8 +143,24 @@ func TestAccMSOTenantPoliciesIGMPInterfacePolicyResource(t *testing.T) {
 	})
 }
 
+func testAccMSOTenantPoliciesIGMPStateLimitRouteMapConfig() string {
+	return `
+    resource "mso_tenant_policies_route_map_policy_multicast" "state_limit" {
+        template_id = mso_template.template_tenant.id
+        name        = "tf_test_state_limit"
+        route_map_multicast_entries {
+            order               = 1
+            group_ip            = "226.2.2.2/8"
+            source_ip           = "1.1.1.1/1"
+            rendezvous_point_ip = "1.1.1.2"
+            action              = "permit"
+        }
+    }
+`
+}
+
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigCreate() string {
-	return fmt.Sprintf(`%s
+	return fmt.Sprintf(`%s%s
     resource "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
         template_id                 = mso_template.template_tenant.id
         name                        = "test_igmp_interface_policy"
@@ -162,11 +180,12 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigCreate() string {
         robustness_variable         = 2
         maximum_multicast_entries   = 1000000
         reserved_multicast_entries  = 100000
-    }`, testAccMSOTemplateResourceTenantConfig())
+        state_limit_route_map_uuid  = mso_tenant_policies_route_map_policy_multicast.state_limit.uuid
+    }`, testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPStateLimitRouteMapConfig())
 }
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateV2() string {
-	return fmt.Sprintf(`%s
+	return fmt.Sprintf(`%s%s
     resource "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
         template_id                 = mso_template.template_tenant.id
         name                        = "test_igmp_interface_policy"
@@ -184,7 +203,9 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateV2() string {
         startup_query_interval      = 31
         querier_timeout             = 255
         robustness_variable         = 2
-    }`, testAccMSOTemplateResourceTenantConfig())
+        reserved_multicast_entries  = 0
+        state_limit_route_map_uuid  = ""
+    }`, testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPStateLimitRouteMapConfig())
 }
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateWithRouteMaps() string {
@@ -311,7 +332,7 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateTimers() string {
 }
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateMaxValues() string {
-	return fmt.Sprintf(`%s
+	return fmt.Sprintf(`%s%s
     resource "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
         template_id                 = mso_template.template_tenant.id
         name                        = "test_igmp_interface_policy_max"
@@ -331,11 +352,12 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateMaxValues() string {
         robustness_variable         = 7
         maximum_multicast_entries   = 4294967295
         reserved_multicast_entries  = 4294967295
-    }`, testAccMSOTemplateResourceTenantConfig())
+        state_limit_route_map_uuid  = mso_tenant_policies_route_map_policy_multicast.state_limit.uuid
+    }`, testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPStateLimitRouteMapConfig())
 }
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateMinValues() string {
-	return fmt.Sprintf(`%s
+	return fmt.Sprintf(`%s%s
     resource "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
         template_id                 = mso_template.template_tenant.id
         name                        = "test_igmp_interface_policy_min"
@@ -355,7 +377,8 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateMinValues() string {
         robustness_variable         = 1
         maximum_multicast_entries   = 1
         reserved_multicast_entries  = 0
-    }`, testAccMSOTemplateResourceTenantConfig())
+        state_limit_route_map_uuid  = ""
+    }`, testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPStateLimitRouteMapConfig())
 }
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateName() string {

--- a/mso/resource_mso_tenant_policies_igmp_interface_policy_test.go
+++ b/mso/resource_mso_tenant_policies_igmp_interface_policy_test.go
@@ -208,47 +208,36 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateV2() string {
     }`, testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPStateLimitRouteMapConfig())
 }
 
-func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateWithRouteMaps() string {
+func testAccMSOTenantPoliciesIGMPAllRouteMapsConfig() string {
 	return fmt.Sprintf(`%s
-    resource "mso_tenant_policies_route_map_policy_multicast" "state_limit" {
-		template_id = mso_template.template_tenant.id
-		name        = "tf_test_state_limit"
-		description = "Terraform test Route Map Policy for Multicast"
-		route_map_multicast_entries {
-			order                   = 1
-			group_ip                = "226.2.2.2/8"
-			source_ip               = "1.1.1.1/1"
-			rendezvous_point_ip     = "1.1.1.2"
-			action                  = "permit"
-		}
-	}
-
     resource "mso_tenant_policies_route_map_policy_multicast" "report_policy" {
-		template_id = mso_tenant_policies_route_map_policy_multicast.state_limit.template_id
-		name        = "tf_test_report_policy"
-		description = "Terraform test Route Map Policy for Multicast"
-		route_map_multicast_entries {
-			order                   = 1
-			group_ip                = "226.2.2.2/8"
-			source_ip               = "1.1.1.1/1"
-			rendezvous_point_ip     = "1.1.1.2"
-			action                  = "permit"
-		}
-	}
+        template_id = mso_tenant_policies_route_map_policy_multicast.state_limit.template_id
+        name        = "tf_test_report_policy"
+        route_map_multicast_entries {
+            order               = 1
+            group_ip            = "226.2.2.2/8"
+            source_ip           = "1.1.1.1/1"
+            rendezvous_point_ip = "1.1.1.2"
+            action              = "permit"
+        }
+    }
 
-	resource "mso_tenant_policies_route_map_policy_multicast" "static_report" {
-		template_id = mso_tenant_policies_route_map_policy_multicast.report_policy.template_id
-		name        = "tf_test_static_report"
-		description = "Terraform test Route Map Policy for Multicast"
-		route_map_multicast_entries {
-			order                   = 1
-			group_ip                = "226.2.2.2/8"
-			source_ip               = "1.1.1.1/1"
-			rendezvous_point_ip     = "1.1.1.2"
-			action                  = "permit"
-		}
-	}
+    resource "mso_tenant_policies_route_map_policy_multicast" "static_report" {
+        template_id = mso_tenant_policies_route_map_policy_multicast.report_policy.template_id
+        name        = "tf_test_static_report"
+        route_map_multicast_entries {
+            order               = 1
+            group_ip            = "226.2.2.2/8"
+            source_ip           = "1.1.1.1/1"
+            rendezvous_point_ip = "1.1.1.2"
+            action              = "permit"
+        }
+    }
+`, testAccMSOTenantPoliciesIGMPStateLimitRouteMapConfig())
+}
 
+func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateWithRouteMaps() string {
+	return fmt.Sprintf(`%s%s
     resource "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
         template_id                    = mso_template.template_tenant.id
         name                           = "test_igmp_interface_policy"
@@ -258,58 +247,20 @@ func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateWithRouteMaps() stri
         report_policy_route_map_uuid   = mso_tenant_policies_route_map_policy_multicast.report_policy.uuid
         static_report_route_map_uuid   = mso_tenant_policies_route_map_policy_multicast.static_report.uuid
         maximum_multicast_entries      = 5000000
-    }`, testAccMSOTemplateResourceTenantConfig())
+    }`, testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPAllRouteMapsConfig())
 }
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateRemoveRouteMaps() string {
-	return fmt.Sprintf(`%s
-	resource "mso_tenant_policies_route_map_policy_multicast" "state_limit" {
-		template_id = mso_template.template_tenant.id
-		name        = "tf_test_state_limit"
-		description = "Terraform test Route Map Policy for Multicast"
-		route_map_multicast_entries {
-			order                   = 1
-			group_ip                = "226.2.2.2/8"
-			source_ip               = "1.1.1.1/1"
-			rendezvous_point_ip     = "1.1.1.2"
-			action                  = "permit"
-		}
-	}
-
-    resource "mso_tenant_policies_route_map_policy_multicast" "report_policy" {
-		template_id = mso_tenant_policies_route_map_policy_multicast.state_limit.template_id
-		name        = "tf_test_report_policy"
-		description = "Terraform test Route Map Policy for Multicast"
-		route_map_multicast_entries {
-			order                   = 1
-			group_ip                = "226.2.2.2/8"
-			source_ip               = "1.1.1.1/1"
-			rendezvous_point_ip     = "1.1.1.2"
-			action                  = "permit"
-		}
-	}
-
-	resource "mso_tenant_policies_route_map_policy_multicast" "static_report" {
-		template_id = mso_tenant_policies_route_map_policy_multicast.report_policy.template_id
-		name        = "tf_test_static_report"
-		description = "Terraform test Route Map Policy for Multicast"
-		route_map_multicast_entries {
-			order                   = 1
-			group_ip                = "226.2.2.2/8"
-			source_ip               = "1.1.1.1/1"
-			rendezvous_point_ip     = "1.1.1.2"
-			action                  = "permit"
-		}
-	}
+	return fmt.Sprintf(`%s%s
     resource "mso_tenant_policies_igmp_interface_policy" "igmp_policy" {
-        template_id                 = mso_template.template_tenant.id
-        name                        = "test_igmp_interface_policy"
-        description                 = "Route Maps Removed"
-        igmp_version                = "v3"
-        state_limit_route_map_uuid  = ""
+        template_id                  = mso_template.template_tenant.id
+        name                         = "test_igmp_interface_policy"
+        description                  = "Route Maps Removed"
+        igmp_version                 = "v3"
+        state_limit_route_map_uuid   = ""
         report_policy_route_map_uuid = ""
         static_report_route_map_uuid = ""
-    }`, testAccMSOTemplateResourceTenantConfig())
+    }`, testAccMSOTemplateResourceTenantConfig(), testAccMSOTenantPoliciesIGMPAllRouteMapsConfig())
 }
 
 func testAccMSOTenantPoliciesIGMPInterfacePolicyConfigUpdateTimers() string {


### PR DESCRIPTION
Confirmed tests pass on ND 3.2, 4.1, 4.2.

In ND 4.2 state_limit_route_map is required when setting reserved_multicast_entries to a value other than 0.