### PR TITLE
[minor_change] mso_schema_template_service_graph: fix bugs and remove deprecated service_node_type (DCNE-785)

### DIFF
--- a/mso/datasource_mso_schema_template_service_graph.go
+++ b/mso/datasource_mso_schema_template_service_graph.go
@@ -33,12 +33,6 @@ func dataSourceMSOSchemaTemplateServiceGraph() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1000),
 			},
-			"service_node_type": &schema.Schema{
-				Type:          schema.TypeString,
-				Computed:      true,
-				ConflictsWith: []string{"service_node"},
-				Deprecated:    "Use service_node to configure service nodes.",
-			},
 			"service_node": &schema.Schema{
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -72,10 +66,7 @@ func dataSourceMSOSchemaTemplateServiceGraphRead(d *schema.ResourceData, m inter
 	}
 
 	stateTemplate := d.Get("template_name").(string)
-	var graphName string
-	if tempVar, ok := d.GetOk("service_graph_name"); ok {
-		graphName = tempVar.(string)
-	}
+	graphName := d.Get("service_graph_name").(string)
 
 	sgCont, _, err := getTemplateServiceGraphCont(cont, stateTemplate, graphName)
 
@@ -84,28 +75,24 @@ func dataSourceMSOSchemaTemplateServiceGraphRead(d *schema.ResourceData, m inter
 		return err
 	}
 
-	if tempVar, ok := d.GetOk("service_node_type"); ok {
-		serviceNodeType := tempVar.(string)
-		d.Set("service_node_type", serviceNodeType)
-	} else {
-		serviceNodeList := make([]interface{}, 0, 1)
-		for _, val := range sgCont.S("serviceNodes").Data().([]interface{}) {
-			nodeType, err := getNodeNameFromId(msoClient, models.StripQuotes(val.(map[string]interface{})["serviceNodeTypeId"].(string)))
-			if err != nil {
-				return err
-			}
-			serviceNodeMap := map[string]interface{}{
-				"type": nodeType,
-			}
-
-			serviceNodeList = append(serviceNodeList, serviceNodeMap)
+	serviceNodeList := make([]interface{}, 0, 1)
+	for _, val := range sgCont.S("serviceNodes").Data().([]interface{}) {
+		nodeType, err := getNodeNameFromId(msoClient, models.StripQuotes(val.(map[string]interface{})["serviceNodeTypeId"].(string)))
+		if err != nil {
+			return err
 		}
-		d.Set("service_node", serviceNodeList)
+		serviceNodeMap := map[string]interface{}{
+			"type": nodeType,
+		}
+
+		serviceNodeList = append(serviceNodeList, serviceNodeMap)
 	}
+	d.Set("service_node", serviceNodeList)
 
 	d.Set("schema_id", schemaId)
 	d.Set("template_name", stateTemplate)
 	d.Set("service_graph_name", graphName)
+	d.Set("description", models.StripQuotes(sgCont.S("description").String()))
 	d.SetId(fmt.Sprintf("%s/templates/%s/serviceGraphs/%s", schemaId, stateTemplate, graphName))
 	log.Printf("[DEBUG] %s: Datasource read finished successfully", d.Id())
 	return nil

--- a/mso/datasource_mso_schema_template_service_graph_test.go
+++ b/mso/datasource_mso_schema_template_service_graph_test.go
@@ -1,0 +1,59 @@
+package mso
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccMSOSchemaTemplateServiceGraphDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				PreConfig:   func() { fmt.Println("Test: Schema Template Service Graph Data Source - Not Found") },
+				Config:      testAccMSOSchemaTemplateServiceGraphDataSourceNotFound(),
+				ExpectError: regexp.MustCompile(`unable to find service graph`),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Schema Template Service Graph Data Source") },
+				Config:    testAccMSOSchemaTemplateServiceGraphDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "schema_id"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "template_name", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_graph_name", msoSchemaTemplateServiceGraphName),
+					resource.TestCheckResourceAttr("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "description", "Terraform test service graph"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.#", "3"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.0.type", "firewall"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.1.type", "load-balancer"),
+					resource.TestCheckResourceAttr("data.mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.2.type", msoServiceNodeTypeName),
+				),
+			},
+		},
+	})
+}
+
+func testAccMSOSchemaTemplateServiceGraphDataSourceNotFound() string {
+	return fmt.Sprintf(`%s
+
+data "mso_schema_template_service_graph" "%[2]s" {
+  schema_id          = mso_schema_template_service_graph.%[2]s.schema_id
+  template_name      = mso_schema_template_service_graph.%[2]s.template_name
+  service_graph_name = "non_existing_service_graph"
+}
+`, testAccMSOSchemaTemplateServiceGraphConfigCreate(), msoSchemaTemplateServiceGraphName)
+}
+
+func testAccMSOSchemaTemplateServiceGraphDataSourceConfig() string {
+	return fmt.Sprintf(`%s
+
+data "mso_schema_template_service_graph" "%[2]s" {
+  schema_id          = mso_schema_template_service_graph.%[2]s.schema_id
+  template_name      = mso_schema_template_service_graph.%[2]s.template_name
+  service_graph_name = mso_schema_template_service_graph.%[2]s.service_graph_name
+}
+`, testAccMSOSchemaTemplateServiceGraphConfigThreeNodes("Terraform test service graph"), msoSchemaTemplateServiceGraphName)
+}

--- a/mso/resource_mso_schema_site_service_graph.go
+++ b/mso/resource_mso_schema_site_service_graph.go
@@ -374,3 +374,93 @@ func setServiceNodeList(graphCont *container.Container) ([]interface{}, error) {
 	}
 	return serviceNodeList, nil
 }
+
+func getSiteServiceNodeCont(graphCont *container.Container, schemaId, templateName, graphName, nodeName string) (*container.Container, int, error) {
+	nodesCount, err := graphCont.ArrayCount("serviceNodes")
+	if err != nil {
+		return nil, -1, fmt.Errorf("Unable to load site service node count")
+	}
+	for i := 0; i < nodesCount; i++ {
+		nodeCont, err := graphCont.ArrayElement(i, "serviceNodes")
+		if err != nil {
+			return nil, -1, fmt.Errorf("Unable to load site service node element")
+		}
+
+		nodeRef := models.StripQuotes(nodeCont.S("serviceNodeRef").String())
+
+		nodeSplit := strings.Split(nodeRef, "/")
+		if len(nodeSplit) == 9 {
+			if nodeSplit[2] == schemaId && nodeSplit[4] == templateName && nodeSplit[6] == graphName && nodeSplit[8] == nodeName {
+				return nodeCont, i, nil
+			}
+		} else {
+			return nil, -1, fmt.Errorf("Spilt on nodeRef failed")
+		}
+	}
+	return nil, -1, fmt.Errorf("Unable to find site service node")
+}
+
+func getSiteServiceGraphCont(cont *container.Container, schemaId, templateName, siteId, graphName string) (*container.Container, int, error) {
+	sitesCount, err := cont.ArrayCount("sites")
+	if err != nil {
+		return nil, -1, fmt.Errorf("Unable to find sites")
+	}
+
+	for i := 0; i < sitesCount; i++ {
+		siteCont, err := cont.ArrayElement(i, "sites")
+		if err != nil {
+			return nil, -1, fmt.Errorf("Unable to load site element")
+		}
+
+		siteTemplate := models.StripQuotes(siteCont.S("templateName").String())
+		apiSiteId := models.StripQuotes(siteCont.S("siteId").String())
+
+		if siteTemplate == templateName && siteId == apiSiteId {
+			sgCount, err := siteCont.ArrayCount("serviceGraphs")
+			if err != nil {
+				return nil, -1, fmt.Errorf("Unable to load site service graphs")
+			}
+			for j := 0; j < sgCount; j++ {
+				sgCont, err := siteCont.ArrayElement(j, "serviceGraphs")
+				if err != nil {
+					return nil, -1, fmt.Errorf("Unable to load site service graph element")
+				}
+
+				graphRef := models.StripQuotes(sgCont.S("serviceGraphRef").String())
+				graphEle := strings.Split(graphRef, "/")
+
+				if len(graphEle) != 7 {
+					return nil, -1, fmt.Errorf("Invalid site service graph")
+				}
+
+				if schemaId == graphEle[2] && templateName == graphEle[4] && graphName == graphEle[6] {
+					return sgCont, j, nil
+				}
+			}
+		}
+	}
+
+	return nil, -1, fmt.Errorf("Unable to find site service graph")
+}
+
+func getTemplateServiceNodeCont(cont *container.Container, nodeName, nodeType string) (*container.Container, int, error) {
+	nodeCount, err := cont.ArrayCount("serviceNodes")
+	if err != nil {
+		return nil, -1, fmt.Errorf("Unable to load node count")
+	}
+
+	for i := 0; i < nodeCount; i++ {
+		nodeCont, err := cont.ArrayElement(i, "serviceNodes")
+		if err != nil {
+			return nil, -1, fmt.Errorf("Unable to load node element")
+		}
+
+		apiNodeName := models.StripQuotes(nodeCont.S("name").String())
+		apiNodeType := models.StripQuotes(nodeCont.S("serviceNodeTypeId").String())
+
+		if apiNodeName == nodeName && apiNodeType == nodeType {
+			return nodeCont, i, nil
+		}
+	}
+	return nil, -1, fmt.Errorf("Unable to find the service node")
+}

--- a/mso/resource_mso_schema_template_service_graph.go
+++ b/mso/resource_mso_schema_template_service_graph.go
@@ -1,7 +1,6 @@
 package mso
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -45,29 +44,17 @@ func resourceMSOSchemaTemplateServiceGraphs() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1000),
 			},
-			"service_node_type": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ValidateFunc:  validation.StringLenBetween(1, 1000),
-				ConflictsWith: []string{"service_node"},
-				Deprecated:    "Use service_node to configure service nodes.",
-			},
 			"service_node": &schema.Schema{
 				Type:        schema.TypeList,
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
+				MinItems:    1,
 				Description: "Configure service nodes for the service graph.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"firewall",
-								"load-balancer",
-								"other",
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1000),
 						},
 					},
 				},
@@ -75,18 +62,9 @@ func resourceMSOSchemaTemplateServiceGraphs() *schema.Resource {
 			"description": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(1, 1000),
+				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 		}),
-		CustomizeDiff: func(diff *schema.ResourceDiff, v interface{}) error {
-			_, service_node_type := diff.GetOk("service_node_type")
-			_, service_node := diff.GetOk("service_node")
-			if !service_node_type && !service_node {
-				return errors.New(`"service_node" is required.`)
-			}
-			return nil
-		},
 	}
 }
 
@@ -132,7 +110,6 @@ func resourceMSOSchemaTemplateServiceGraphImport(d *schema.ResourceData, m inter
 		serviceNodeList = append(serviceNodeList, serviceNodeMap)
 	}
 	d.Set("service_node", serviceNodeList)
-	d.Set("service_node_type", serviceNodeList[0].(map[string]interface{})["type"])
 
 	d.SetId(fmt.Sprintf("%s/templates/%s/serviceGraphs/%s", schemaId, templateName, graphName))
 	log.Printf("[DEBUG] %s: Import finished successfully", d.Id())
@@ -140,7 +117,7 @@ func resourceMSOSchemaTemplateServiceGraphImport(d *schema.ResourceData, m inter
 }
 
 func resourceMSOSchemaTemplateServiceGraphCreate(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Begining Creation Template Service Graph")
+	log.Printf("[DEBUG] Beginning Creation Template Service Graph")
 	msoClient := m.(*client.Client)
 
 	var schemaId string
@@ -202,10 +179,7 @@ func resourceMSOSchemaTemplateServiceGraphRead(d *schema.ResourceData, m interfa
 	}
 
 	templateName := d.Get("template_name").(string)
-	var graphName string
-	if tempVar, ok := d.GetOk("service_graph_name"); ok {
-		graphName = tempVar.(string)
-	}
+	graphName := d.Get("service_graph_name").(string)
 
 	sgCont, _, err := getTemplateServiceGraphCont(cont, templateName, graphName)
 	if err != nil {
@@ -214,27 +188,22 @@ func resourceMSOSchemaTemplateServiceGraphRead(d *schema.ResourceData, m interfa
 		return nil
 	}
 
-	if tempVar, ok := d.GetOk("service_node_type"); ok {
-		serviceNodeType := tempVar.(string)
-		d.Set("service_node_type", serviceNodeType)
-	} else {
-		serviceNodeList := make([]interface{}, 0, 1)
-		serviceNodes := sgCont.S("serviceNodes").Data().([]interface{})
-		for _, val := range serviceNodes {
-			serviceNodeValues := val.(map[string]interface{})
-			serviceNodeMap := make(map[string]interface{})
-			nodeId := models.StripQuotes(serviceNodeValues["serviceNodeTypeId"].(string))
+	serviceNodeList := make([]interface{}, 0, 1)
+	serviceNodes := sgCont.S("serviceNodes").Data().([]interface{})
+	for _, val := range serviceNodes {
+		serviceNodeValues := val.(map[string]interface{})
+		serviceNodeMap := make(map[string]interface{})
+		nodeId := models.StripQuotes(serviceNodeValues["serviceNodeTypeId"].(string))
 
-			nodeType, err := getNodeNameFromId(msoClient, nodeId)
-			if err != nil {
-				return err
-			}
-			serviceNodeMap["type"] = nodeType
-
-			serviceNodeList = append(serviceNodeList, serviceNodeMap)
+		nodeType, err := getNodeNameFromId(msoClient, nodeId)
+		if err != nil {
+			return err
 		}
-		d.Set("service_node", serviceNodeList)
+		serviceNodeMap["type"] = nodeType
+
+		serviceNodeList = append(serviceNodeList, serviceNodeMap)
 	}
+	d.Set("service_node", serviceNodeList)
 
 	d.Set("schema_id", schemaId)
 	d.Set("template_name", templateName)
@@ -246,7 +215,7 @@ func resourceMSOSchemaTemplateServiceGraphRead(d *schema.ResourceData, m interfa
 }
 
 func resourceMSOSchemaTemplateServiceGraphUpdate(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Begining Update Template Service Graph")
+	log.Printf("[DEBUG] Beginning Update Template Service Graph")
 	msoClient := m.(*client.Client)
 
 	var schemaId string
@@ -265,23 +234,15 @@ func resourceMSOSchemaTemplateServiceGraphUpdate(d *schema.ResourceData, m inter
 	}
 
 	if d.HasChange("description") {
-		var desc string
-		if tempVar, ok := d.GetOk("description"); ok {
-			desc = tempVar.(string)
-		} else {
-			desc = ""
-		}
-
 		templatePath := fmt.Sprintf("/templates/%s/serviceGraphs/%s/description", templateName, graphName)
-		graphUpdate := models.NewTemplateServiceGraphUpdate("replace", templatePath, desc)
+		graphUpdate := models.NewTemplateServiceGraphUpdate("replace", templatePath, d.Get("description").(string))
 		_, err := msoClient.PatchbyID(fmt.Sprintf("/api/v1/schemas/%s", schemaId), graphUpdate)
 		if err != nil {
 			return err
 		}
-
 	}
 
-	if d.HasChange("service_node_type") || d.HasChange("service_node") {
+	if d.HasChange("service_node") {
 		templatePath := fmt.Sprintf("/templates/%s/serviceGraphs/%s/serviceNodes", templateName, graphName)
 		serviceNodes, err := getServiceGraphNodes(d, msoClient)
 		if err != nil {
@@ -332,99 +293,6 @@ func resourceMSOSchemaTemplateServiceGraphDelete(d *schema.ResourceData, m inter
 	d.SetId("")
 
 	return nil
-}
-
-func getSiteServiceNodeCont(graphCont *container.Container, schemaId, templateName, graphName, nodeName string) (*container.Container, int, error) {
-
-	nodesCount, err := graphCont.ArrayCount("serviceNodes")
-	if err != nil {
-		return nil, -1, fmt.Errorf("Unable to load count site service node")
-	}
-	for i := 0; i < nodesCount; i++ {
-		nodeCont, err := graphCont.ArrayElement(i, "serviceNodes")
-		if err != nil {
-			return nil, -1, fmt.Errorf("Unable to site service node element")
-		}
-
-		nodeRef := models.StripQuotes(nodeCont.S("serviceNodeRef").String())
-
-		nodeSplit := strings.Split(nodeRef, "/")
-		if len(nodeSplit) == 9 {
-			if nodeSplit[2] == schemaId && nodeSplit[4] == templateName && nodeSplit[6] == graphName && nodeSplit[8] == nodeName {
-				return nodeCont, i, nil
-
-			}
-		} else {
-			return nil, -1, fmt.Errorf("Spilt on nodeRef failed")
-		}
-	}
-	return nil, -1, fmt.Errorf("Unable to find site service node")
-}
-func getSiteServiceGraphCont(cont *container.Container, schemaId, templateName, siteId, graphName string) (*container.Container, int, error) {
-	sitesCount, err := cont.ArrayCount("sites")
-
-	if err != nil {
-		return nil, -1, fmt.Errorf("Unable to find sites")
-	}
-
-	for i := 0; i < sitesCount; i++ {
-		siteCont, err := cont.ArrayElement(i, "sites")
-		if err != nil {
-			return nil, -1, fmt.Errorf("Unable to load site element")
-		}
-
-		siteTemplate := models.StripQuotes(siteCont.S("templateName").String())
-		apiSiteId := models.StripQuotes(siteCont.S("siteId").String())
-
-		if siteTemplate == templateName && siteId == apiSiteId {
-			sgCount, err := siteCont.ArrayCount("serviceGraphs")
-			if err != nil {
-				return nil, -1, fmt.Errorf("Unable to load site service graphs")
-			}
-			for j := 0; j < sgCount; j++ {
-				sgCont, err := siteCont.ArrayElement(j, "serviceGraphs")
-				if err != nil {
-					return nil, -1, fmt.Errorf("Unable to load site service graph element")
-				}
-
-				graphRef := models.StripQuotes(sgCont.S("serviceGraphRef").String())
-				graphEle := strings.Split(graphRef, "/")
-
-				if len(graphEle) != 7 {
-					return nil, -1, fmt.Errorf("Inavlid site service graph")
-				}
-
-				if schemaId == graphEle[2] && templateName == graphEle[4] && graphName == graphEle[6] {
-					return sgCont, j, nil
-				}
-			}
-		}
-	}
-
-	return nil, -1, fmt.Errorf("Unable to find site service graph")
-}
-
-func getTemplateServiceNodeCont(cont *container.Container, nodeName, nodeType string) (*container.Container, int, error) {
-
-	nodeCount, err := cont.ArrayCount("serviceNodes")
-	if err != nil {
-		return nil, -1, fmt.Errorf("Unable to load node count")
-	}
-
-	for i := 0; i < nodeCount; i++ {
-		nodeCont, err := cont.ArrayElement(i, "serviceNodes")
-		if err != nil {
-			return nil, -1, fmt.Errorf("Unable to load node element")
-		}
-
-		apiNodeName := models.StripQuotes(nodeCont.S("name").String())
-		apiNodeType := models.StripQuotes(nodeCont.S("serviceNodeTypeId").String())
-
-		if apiNodeName == nodeName && apiNodeType == nodeType {
-			return nodeCont, i, nil
-		}
-	}
-	return nil, -1, fmt.Errorf("Unable to find the service node")
 }
 
 func getTemplateServiceGraphCont(cont *container.Container, templateName, graphName string) (*container.Container, int, error) {
@@ -507,7 +375,7 @@ func getNodeNameFromId(msoClient *client.Client, nodeId string) (string, error) 
 		}
 	}
 
-	return "", fmt.Errorf("Unable to find nodeNamefor nodeid %s", nodeId)
+	return "", fmt.Errorf("Unable to find nodeName for nodeId %s", nodeId)
 }
 
 func getServiceGraphNodes(d *schema.ResourceData, msoClient *client.Client) ([]interface{}, error) {
@@ -522,36 +390,20 @@ func getServiceGraphNodes(d *schema.ResourceData, msoClient *client.Client) ([]i
 	}
 
 	serviceNodes := make([]interface{}, 0, 1)
-	if tempVar, ok := d.GetOk("service_node_type"); ok {
-		serviceNodeType := tempVar.(string)
-		nodeId, err := getNodeIdFromName(cont, nodesCount, serviceNodeType)
-		if err != nil {
-			return nil, err
-		}
-		serviceNode := map[string]interface{}{
-			"name":              "node1",
-			"index":             1,
-			"serviceNodeTypeId": nodeId,
-		}
-		serviceNodes = append(serviceNodes, serviceNode)
-	} else {
-		if val, ok := d.GetOk("service_node"); ok {
-			for i, val := range val.([]interface{}) {
-				serviceNodeValues := val.(map[string]interface{})
-				if serviceNodeValues["type"] != "" {
-					nodeId, err := getNodeIdFromName(cont, nodesCount, fmt.Sprintf("%v", serviceNodeValues["type"]))
-					if err != nil {
-						return nil, err
-					}
-					index := i + 1
-					serviceNodeMap := map[string]interface{}{
-						"name":              fmt.Sprintf("node%v", index),
-						"index":             index,
-						"serviceNodeTypeId": nodeId,
-					}
-					serviceNodes = append(serviceNodes, serviceNodeMap)
-				}
+	for i, val := range d.Get("service_node").([]interface{}) {
+		serviceNodeValues := val.(map[string]interface{})
+		if serviceNodeValues["type"] != "" {
+			nodeId, err := getNodeIdFromName(cont, nodesCount, fmt.Sprintf("%v", serviceNodeValues["type"]))
+			if err != nil {
+				return nil, err
 			}
+			index := i + 1
+			serviceNodeMap := map[string]interface{}{
+				"name":              fmt.Sprintf("node%v", index),
+				"index":             index,
+				"serviceNodeTypeId": nodeId,
+			}
+			serviceNodes = append(serviceNodes, serviceNodeMap)
 		}
 	}
 	return serviceNodes, nil

--- a/mso/resource_mso_schema_template_service_graph_test.go
+++ b/mso/resource_mso_schema_template_service_graph_test.go
@@ -1,0 +1,177 @@
+package mso
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ciscoecosystem/mso-go-client/client"
+	"github.com/ciscoecosystem/mso-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// msoSchemaTemplateServiceGraphSchemaId is set during the first test step's Check to capture the dynamic schema ID for use in the manual deletion PreConfig step.
+var msoSchemaTemplateServiceGraphSchemaId string
+
+func TestAccMSOSchemaTemplateServiceGraphResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMSOSchemaTemplateServiceGraphDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					fmt.Println("Test: Create Schema Template Service Graph with a single firewall node and description")
+				},
+				Config: testAccMSOSchemaTemplateServiceGraphConfigCreate(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "template_name", msoSchemaTemplateName),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_graph_name", msoSchemaTemplateServiceGraphName),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "description", "Terraform test service graph"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.#", "1"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.0.type", "firewall"),
+					// Capture the dynamic schema ID from state for use in the manual deletion PreConfig step
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName]
+						if !ok {
+							return fmt.Errorf("Service Graph resource not found in state")
+						}
+						msoSchemaTemplateServiceGraphSchemaId = rs.Primary.Attributes["schema_id"]
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					fmt.Println("Test: Update Schema Template Service Graph description and add a second service node (load-balancer) and third custom service node")
+				},
+				Config: testAccMSOSchemaTemplateServiceGraphConfigUpdateThreeNodes(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_graph_name", msoSchemaTemplateServiceGraphName),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "description", "Terraform test service graph updated"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.#", "3"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.0.type", "firewall"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.1.type", "load-balancer"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.2.type", msoServiceNodeTypeName),
+				),
+			},
+			{
+				PreConfig: func() {
+					fmt.Println("Test: Update Schema Template Service Graph to remove description")
+				},
+				Config: testAccMSOSchemaTemplateServiceGraphConfigRemoveDescription(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_graph_name", msoSchemaTemplateServiceGraphName),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "description", ""),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.#", "3"),
+				),
+			},
+			{
+				PreConfig:         func() { fmt.Println("Test: Import Schema Template Service Graph") },
+				ResourceName:      "mso_schema_template_service_graph." + msoSchemaTemplateServiceGraphName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				PreConfig: func() {
+					fmt.Println("Test: Recreate Schema Template Service Graph after manual deletion from NDO")
+					msoClient := testAccProvider.Meta().(*client.Client)
+					path := fmt.Sprintf("/templates/%s/serviceGraphs/%s", msoSchemaTemplateName, msoSchemaTemplateServiceGraphName)
+					_, err := msoClient.PatchbyID(
+						fmt.Sprintf("api/v1/schemas/%s", msoSchemaTemplateServiceGraphSchemaId),
+						models.GetRemovePatchPayload(path),
+					)
+					if err != nil {
+						t.Fatalf("Failed to manually delete Service Graph: %v", err)
+					}
+				},
+				Config: testAccMSOSchemaTemplateServiceGraphConfigCreate(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "schema_id"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_graph_name", msoSchemaTemplateServiceGraphName),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "description", "Terraform test service graph"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.#", "1"),
+					resource.TestCheckResourceAttr("mso_schema_template_service_graph."+msoSchemaTemplateServiceGraphName, "service_node.0.type", "firewall"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMSOSchemaTemplateServiceGraphDestroy(s *terraform.State) error {
+	msoClient := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mso_schema_template_service_graph" {
+			continue
+		}
+		schemaId := rs.Primary.Attributes["schema_id"]
+		cont, err := msoClient.GetViaURL(fmt.Sprintf("api/v1/schemas/%s", schemaId))
+		if err != nil {
+			return nil
+		}
+		_, _, err = getTemplateServiceGraphCont(cont, rs.Primary.Attributes["template_name"], rs.Primary.Attributes["service_graph_name"])
+		if err == nil {
+			return fmt.Errorf("Schema Template Service Graph still exists")
+		}
+	}
+	return nil
+}
+
+func testAccMSOSchemaTemplateServiceGraphDependencies() string {
+	return fmt.Sprintf(`%s%s%s`, testSiteConfigAnsibleTest(), testTenantConfig(), testSchemaConfig())
+}
+
+func testAccMSOSchemaTemplateServiceGraphConfigCreate() string {
+	return fmt.Sprintf(`%s
+resource "mso_schema_template_service_graph" "%[2]s" {
+  schema_id          = mso_schema.%[3]s.id
+  template_name      = "%[4]s"
+  service_graph_name = "%[2]s"
+  description        = "Terraform test service graph"
+
+  service_node {
+    type = "firewall"
+  }
+}
+`, testAccMSOSchemaTemplateServiceGraphDependencies(), msoSchemaTemplateServiceGraphName, msoSchemaName, msoSchemaTemplateName)
+}
+
+func testAccMSOSchemaTemplateServiceGraphConfigUpdateThreeNodes() string {
+	return testAccMSOSchemaTemplateServiceGraphConfigThreeNodes("Terraform test service graph updated")
+}
+
+func testAccMSOSchemaTemplateServiceGraphConfigRemoveDescription() string {
+	return testAccMSOSchemaTemplateServiceGraphConfigThreeNodes("")
+}
+
+func testAccMSOSchemaTemplateServiceGraphConfigThreeNodes(description string) string {
+	descLine := ""
+	if description != "" {
+		descLine = fmt.Sprintf("  description        = %q\n", description)
+	}
+	return fmt.Sprintf(`%s
+
+resource "mso_service_node_type" "%[2]s" {
+  name = "%[2]s"
+}
+
+resource "mso_schema_template_service_graph" "%[3]s" {
+  schema_id          = mso_schema.%[4]s.id
+  template_name      = "%[5]s"
+  service_graph_name = "%[3]s"
+%[6]s
+  service_node {
+    type = "firewall"
+  }
+
+  service_node {
+    type = "load-balancer"
+  }
+
+  service_node {
+    type = mso_service_node_type.%[2]s.name
+  }
+}
+`, testAccMSOSchemaTemplateServiceGraphDependencies(), msoServiceNodeTypeName, msoSchemaTemplateServiceGraphName, msoSchemaName, msoSchemaTemplateName, descLine)
+}

--- a/mso/test_constants.go
+++ b/mso/test_constants.go
@@ -56,6 +56,8 @@ var msoSchemaTemplateAnpEpgUsegAttrName2 = acctest.RandStringFromCharSet(10, acc
 var msoServiceDeviceTemplateName = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 var msoServiceDeviceClusterLbName = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 var msoServiceDeviceClusterFwName = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+var msoSchemaTemplateServiceGraphName = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+var msoServiceNodeTypeName = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 // msoSchemaSiteAnpEpgStaticLeafPath is the topology path of the leaf node
 // used in static leaf acceptance tests. It must correspond to a real leaf

--- a/website/docs/d/schema_template_service_graph.html.markdown
+++ b/website/docs/d/schema_template_service_graph.html.markdown
@@ -30,10 +30,6 @@ data "mso_schema_template_service_graph" "example" {
 
 ## Attribute Reference ##
 
-* `service_node_type` - (Read-Only) **Deprecated**. The type of the Service Node.
 * `description` - (Read-Only) Description of Service Graph.
 * `service_node` - (Read-Only) List of service nodes attached to Service Graph.
-    * `type` - (Read-Only) Type of Service Node attached to the Service Graph.
-
-## NOTE ##
-The `site_nodes` parameters are removed from Template level Service Graph datasource.
+    * `type` - (Read-Only) The name of the service node type.

--- a/website/docs/r/schema_template_service_graph.html.markdown
+++ b/website/docs/r/schema_template_service_graph.html.markdown
@@ -18,10 +18,11 @@ resource "mso_schema_template_service_graph" "test_sg" {
   schema_id          = mso_schema.schema1.id
   template_name      = "Template1"
   service_graph_name = "sgtf"
+  description        = "Created by terraform"
+
   service_node {
     type = "firewall"
   }
-  description        = "Created by terraform"
 }
 
 ```
@@ -30,14 +31,12 @@ resource "mso_schema_template_service_graph" "test_sg" {
 * `schema_id` - (Required) The schema ID under which you want to deploy Service Graph.
 * `template_name` - (Required) The template name under which you want to deploy Service Graph.
 * `service_graph_name` - (Required) Name of the Service Graph.
-* `service_node_type` - (Optional) **Deprecated**. Type of Service Node attached to this Graph. Allowed values are `firewall`, `load-balancer` and `other`.
 * `description` - (Optional) Description of Service Graph.
-* `service_node` - (Required) List of service nodes attached to Service Graph.
-    * `type` - (Required) Type of Service Node attached to the Service Graph. Allowed values are `firewall`, `load-balancer` and `other`.
-
+* `service_node` - (Required) List of service nodes attached to the Service Graph. At least one service node is required.
+    * `type` - (Required) The name of the service node type. Built-in values are `firewall`, `load-balancer` and `other`. Custom node types created via `mso_service_node_type` are also supported.
 
 ## NOTE ##
-The `site_nodes` parameters are removed from Template level Service Graph resource.
+The NDO API does not support removing service nodes from an existing Service Graph. To reduce the number of nodes, the Service Graph must be deleted and recreated.
 
 ## Attribute Reference ##
 
@@ -48,5 +47,5 @@ The only Attribute exposed for this resource is `id`. Which is set to the id of 
 An existing MSO Schema Template Service Graph can be [imported][docs-import] into this resource via its Id/path, via the following command: [docs-import]: <https://www.terraform.io/docs/import/index.html>
 
 ```bash
-terraform import mso_schema_template_service_graph.test_sg {schema_id}/template/{template_name}/serviceGraph/{service_graph_name}
+terraform import mso_schema_template_service_graph.test_sg {schema_id}/templates/{template_name}/serviceGraphs/{service_graph_name}
 ```


### PR DESCRIPTION
- Fix mso_schema_template_service_graph update silently reverting to a single service node when description or other attributes changed.
 - Fix mso_schema_template_service_graph datasource missing description in read response.
 - Fix mso_schema_template_service_graph to allow description to be cleared by omitting or setting description to an empty string.
 - Fix mso_schema_template_service_graph service_node type validation to allow custom node types created via mso_service_node_type.
 - Remove deprecated service_node_type attribute from mso_schema_template_service_graph resource and datasource.

Tested on ND 3.2, 4.1 and 4.2