### PR TITLE
[ignore] Add tests for mso_service_node_type (DCNE-786)

### DIFF
--- a/mso/datasource_mso_service_node_type_test.go
+++ b/mso/datasource_mso_service_node_type_test.go
@@ -1,0 +1,58 @@
+package mso
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccMSOServiceNodeTypeDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				PreConfig:   func() { fmt.Println("Test: Service Node Type Data Source - Not Found") },
+				Config:      testAccMSOServiceNodeTypeDataSourceNotFound(),
+				ExpectError: regexp.MustCompile(`Unable to find service node type`),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Service Node Type Data Source") },
+				Config:    testAccMSOServiceNodeTypeDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mso_service_node_type.test", "name", msoServiceNodeTypeName),
+					resource.TestCheckResourceAttr("data.mso_service_node_type.test", "display_name", msoServiceNodeTypeName+" display"),
+					resource.TestCheckResourceAttrPair("data.mso_service_node_type.test", "id", "mso_service_node_type.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMSOServiceNodeTypeDataSourceNotFound() string {
+	return fmt.Sprintf(`
+resource "mso_service_node_type" "test" {
+  name         = "%[1]s"
+  display_name = "%[1]s display"
+}
+
+data "mso_service_node_type" "test" {
+  name = "non_existing_service_node_type"
+}
+`, msoServiceNodeTypeName)
+}
+
+func testAccMSOServiceNodeTypeDataSourceConfig() string {
+	return fmt.Sprintf(`
+resource "mso_service_node_type" "test" {
+  name         = "%[1]s"
+  display_name = "%[1]s display"
+}
+
+data "mso_service_node_type" "test" {
+  name = mso_service_node_type.test.name
+}
+`, msoServiceNodeTypeName)
+}

--- a/mso/resource_mso_service_node_type.go
+++ b/mso/resource_mso_service_node_type.go
@@ -99,13 +99,10 @@ func resourceMSOServiceNodeTypeCreate(d *schema.ResourceData, m interface{}) err
 	}
 
 	nodeType := models.NewServiceNodeType(typeAttr)
-	d.Partial(true)
 	cont, err := msoClient.Save("api/v1/schemas/service-node-types", nodeType)
-
 	if err != nil {
 		return err
 	}
-	d.Partial(false)
 	d.SetId(models.StripQuotes(cont.S("id").String()))
 	log.Printf("[DEBUG] Creation finished successfully %s", d.Id())
 	return resourceMSOServiceNodeTypeRead(d, m)

--- a/mso/resource_mso_service_node_type_test.go
+++ b/mso/resource_mso_service_node_type_test.go
@@ -1,0 +1,125 @@
+package mso
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ciscoecosystem/mso-go-client/client"
+	"github.com/ciscoecosystem/mso-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var msoServiceNodeTypeId string
+
+func TestAccMSOServiceNodeTypeResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMSOServiceNodeTypeDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { fmt.Println("Test: Create Service Node Type") },
+				Config:    testAccMSOServiceNodeTypeConfigCreate(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mso_service_node_type.test", "name", msoServiceNodeTypeName),
+					// display_name defaults to name when not explicitly set
+					resource.TestCheckResourceAttr("mso_service_node_type.test", "display_name", msoServiceNodeTypeName),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["mso_service_node_type.test"]
+						if !ok {
+							return fmt.Errorf("mso_service_node_type.test not found in state")
+						}
+						msoServiceNodeTypeId = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig:    func() { fmt.Println("Test: Import Service Node Type") },
+				ResourceName: "mso_service_node_type.test",
+				ImportState:  true,
+				// The importer looks up by name, so we must pass the name as the import ID.
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["mso_service_node_type.test"]
+					if !ok {
+						return "", fmt.Errorf("mso_service_node_type.test not found in state")
+					}
+					return rs.Primary.Attributes["name"], nil
+				},
+				ImportStateVerify: true,
+			},
+			{
+				PreConfig: func() {
+					fmt.Println("Test: Recreate Service Node Type with explicit display name after manual deletion")
+					c := testAccProvider.Meta().(*client.Client)
+					if err := c.DeletebyId("api/v1/schemas/service-node-types/" + msoServiceNodeTypeId); err != nil {
+						t.Fatalf("Failed to delete service node type %s via API: %s", msoServiceNodeTypeId, err)
+					}
+				},
+				Config: testAccMSOServiceNodeTypeConfigCreateWithDisplayName(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mso_service_node_type.test", "name", msoServiceNodeTypeName),
+					resource.TestCheckResourceAttr("mso_service_node_type.test", "display_name", msoServiceNodeTypeName+" display"),
+				),
+			},
+			{
+				PreConfig:    func() { fmt.Println("Test: Import Service Node Type with explicit display name") },
+				ResourceName: "mso_service_node_type.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["mso_service_node_type.test"]
+					if !ok {
+						return "", fmt.Errorf("mso_service_node_type.test not found in state")
+					}
+					return rs.Primary.Attributes["name"], nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMSOServiceNodeTypeDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*client.Client)
+	cont, err := c.GetViaURL("api/v1/schemas/service-node-types")
+	if err != nil {
+		return err
+	}
+	nodesCount, err := cont.ArrayCount("serviceNodeTypes")
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mso_service_node_type" {
+			continue
+		}
+		for i := 0; i < nodesCount; i++ {
+			nodeCont, err := cont.ArrayElement(i, "serviceNodeTypes")
+			if err != nil {
+				return err
+			}
+			if models.StripQuotes(nodeCont.S("id").String()) == rs.Primary.ID {
+				return fmt.Errorf("Service Node Type %s still exists", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccMSOServiceNodeTypeConfigCreate() string {
+	return fmt.Sprintf(`
+resource "mso_service_node_type" "test" {
+  name = "%s"
+}
+`, msoServiceNodeTypeName)
+}
+
+func testAccMSOServiceNodeTypeConfigCreateWithDisplayName() string {
+	return fmt.Sprintf(`
+resource "mso_service_node_type" "test" {
+  name         = "%s"
+  display_name = "%s display"
+}
+`, msoServiceNodeTypeName, msoServiceNodeTypeName)
+}


### PR DESCRIPTION
Test Pass on ND 3.2, 4.1 and 4.2 ✔️ 

```
ND 4.1

════════════════════════════════════════════════════════════════════════
  Running tests  filter: TestAccMSOServiceNodeType
════════════════════════════════════════════════════════════════════════

=== RUN   TestAccMSOServiceNodeTypeDataSource
Test: Service Node Type Data Source - Not Found
Test: Service Node Type Data Source
--- PASS: TestAccMSOServiceNodeTypeDataSource (3.36s)
=== RUN   TestAccMSOServiceNodeTypeResource
Test: Create Service Node Type
Test: Import Service Node Type
Test: Recreate Service Node Type with explicit display name after manual deletion
Test: Import Service Node Type with explicit display name
--- PASS: TestAccMSOServiceNodeTypeResource (3.74s)
PASS
coverage: 1.3% of statements
ok      github.com/CiscoDevNet/terraform-provider-mso/mso       7.532s  coverage: 1.3% of statements

════════════════════════════════════════════════════════════════════════
  Test Report
════════════════════════════════════════════════════════════════════════
MSO URL: https://10.15.0.126/

  PASSED (2)
────────────────────────────────────────────────────────────────────────
  ✔  TestAccMSOServiceNodeTypeDataSource  (3.36s)
  ✔  TestAccMSOServiceNodeTypeResource  (3.74s)

────────────────────────────────────────────────────────────────────────
  Total: 2   Passed: 2   Failed: 0   Skipped: 0   Elapsed: 10.7s
────────────────────────────────────────────────────────────────────────

ND 4.2

════════════════════════════════════════════════════════════════════════
  Running tests  filter: TestAccMSOServiceNodeType
════════════════════════════════════════════════════════════════════════

=== RUN   TestAccMSOServiceNodeTypeDataSource
Test: Service Node Type Data Source - Not Found
Test: Service Node Type Data Source
--- PASS: TestAccMSOServiceNodeTypeDataSource (3.15s)
=== RUN   TestAccMSOServiceNodeTypeResource
Test: Create Service Node Type
Test: Import Service Node Type
Test: Recreate Service Node Type with explicit display name after manual deletion
Test: Import Service Node Type with explicit display name
--- PASS: TestAccMSOServiceNodeTypeResource (3.70s)
PASS
coverage: 1.3% of statements
ok      github.com/CiscoDevNet/terraform-provider-mso/mso       7.282s  coverage: 1.3% of statements

════════════════════════════════════════════════════════════════════════
  Test Report
════════════════════════════════════════════════════════════════════════
MSO URL: https://10.15.0.127/

  PASSED (2)
────────────────────────────────────────────────────────────────────────
  ✔  TestAccMSOServiceNodeTypeDataSource  (3.15s)
  ✔  TestAccMSOServiceNodeTypeResource  (3.70s)

────────────────────────────────────────────────────────────────────────
  Total: 2   Passed: 2   Failed: 0   Skipped: 0   Elapsed: 11.2s
────────────────────────────────────────────────────────────────────────

ND 3.2

════════════════════════════════════════════════════════════════════════
  Running tests  filter: TestAccMSOServiceNodeType
════════════════════════════════════════════════════════════════════════

=== RUN   TestAccMSOServiceNodeTypeDataSource
Test: Service Node Type Data Source - Not Found
Test: Service Node Type Data Source
--- PASS: TestAccMSOServiceNodeTypeDataSource (3.54s)
=== RUN   TestAccMSOServiceNodeTypeResource
Test: Create Service Node Type
Test: Import Service Node Type
Test: Recreate Service Node Type with explicit display name after manual deletion
Test: Import Service Node Type with explicit display name
--- PASS: TestAccMSOServiceNodeTypeResource (3.92s)
PASS
coverage: 1.3% of statements
ok      github.com/CiscoDevNet/terraform-provider-mso/mso       7.887s  coverage: 1.3% of statements

════════════════════════════════════════════════════════════════════════
  Test Report
════════════════════════════════════════════════════════════════════════
MSO URL: https://10.15.0.128/

  PASSED (2)
────────────────────────────────────────────────────────────────────────
  ✔  TestAccMSOServiceNodeTypeDataSource  (3.54s)
  ✔  TestAccMSOServiceNodeTypeResource  (3.92s)

────────────────────────────────────────────────────────────────────────
  Total: 2   Passed: 2   Failed: 0   Skipped: 0   Elapsed: 11.1s
────────────────────────────────────────────────────────────────────────
```