### PR TITLE
Fix deprecated display_name in tests and add version gates (DCNE-865)

### DIFF
--- a/mso/datasource_mso_tenant_policies_endpoint_mac_tag_policy_test.go
+++ b/mso/datasource_mso_tenant_policies_endpoint_mac_tag_policy_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccMSOTenantPoliciesEndpointMACTagPolicyDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/datasource_mso_tenant_policies_netflow_exporter_test.go
+++ b/mso/datasource_mso_tenant_policies_netflow_exporter_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccMSOTenantPoliciesNetflowExporterDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/datasource_mso_tenant_policies_netflow_monitor_test.go
+++ b/mso/datasource_mso_tenant_policies_netflow_monitor_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccMSOTenantPoliciesNetflowMonitorDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/datasource_mso_tenant_policies_netflow_record_test.go
+++ b/mso/datasource_mso_tenant_policies_netflow_record_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccMSOTenantPoliciesNetflowRecordDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/provider_test.go
+++ b/mso/provider_test.go
@@ -263,6 +263,20 @@ func CustomTestCheckTypeSetElemAttrs(resourceName, setName string, attrsToCheck 
 	}
 }
 
+// testAccVersionCheck skips the test if the NDO version is older than minVersion.
+// Must be called after testAccPreCheck in the same PreCheck function.
+// minVersion should be a version string like "5.1" or "4.0.0.0".
+func testAccVersionCheck(t *testing.T, minVersion string) {
+	t.Helper()
+	result, err := msoClientTest.CompareVersion(minVersion)
+	if err != nil {
+		t.Skipf("Skipping: could not determine NDO version: %s", err)
+	}
+	if result > 0 {
+		t.Skipf("Skipping: requires NDO >= %s", minVersion)
+	}
+}
+
 func setupTestLogCapture(t *testing.T, logLevel string) string {
 	logFile, err := os.CreateTemp("", "tf-acc-test-*.log")
 	if err != nil {

--- a/mso/resource_mso_template_test.go
+++ b/mso/resource_mso_template_test.go
@@ -284,7 +284,6 @@ func testAccTenantConfig() string {
 	%s%s
 	resource "mso_tenant" "%s" {
 		name = "%s"
-		display_name = "%s"
 		site_associations { 
 			site_id = data.mso_site.%s.id 
 		}
@@ -292,7 +291,7 @@ func testAccTenantConfig() string {
 			site_id = data.mso_site.%s.id 
 		}
 	}
-	`, testSiteConfigAnsibleTest(), testSiteConfigAnsibleTest2(), msoTemplateTenantName, msoTemplateTenantName, msoTemplateTenantName, msoTemplateSiteName1, msoTemplateSiteName2)
+	`, testSiteConfigAnsibleTest(), testSiteConfigAnsibleTest2(), msoTemplateTenantName, msoTemplateTenantName, msoTemplateSiteName1, msoTemplateSiteName2)
 }
 
 func testAccMSOTemplateResourceTenantConfigNoSites() string {

--- a/mso/resource_mso_tenant_policies_endpoint_mac_tag_policy_test.go
+++ b/mso/resource_mso_tenant_policies_endpoint_mac_tag_policy_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccMSOTenantPoliciesEndpointMACTagPolicyResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/resource_mso_tenant_policies_netflow_exporter_test.go
+++ b/mso/resource_mso_tenant_policies_netflow_exporter_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccMSOTenantPoliciesNetflowExporterResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/resource_mso_tenant_policies_netflow_monitor_test.go
+++ b/mso/resource_mso_tenant_policies_netflow_monitor_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccMSOTenantPoliciesNetflowMonitorResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/resource_mso_tenant_policies_netflow_record_test.go
+++ b/mso/resource_mso_tenant_policies_netflow_record_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccMSOTenantPoliciesNetflowRecordResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccVersionCheck(t, "5.1") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/mso/resource_ndo_schema_template_deploy_test.go
+++ b/mso/resource_ndo_schema_template_deploy_test.go
@@ -201,12 +201,11 @@ func testAccSingleTenantConfig() string {
     %s
     resource "mso_tenant" "%s" {
         name = "%s"
-        display_name = "%s"
         site_associations { 
             site_id = data.mso_site.%s.id 
         }
     }
-    `, testSiteConfigAnsibleTest(), msoTfTenantName, msoTfTenantName, msoTfTenantName, msoTemplateSiteName1)
+    `, testSiteConfigAnsibleTest(), msoTfTenantName, msoTfTenantName, msoTemplateSiteName1)
 }
 
 func testAccMsoSchemaTemplateErrorCrossTemplateVrfBdConfig() string {

--- a/mso/test_constants.go
+++ b/mso/test_constants.go
@@ -487,8 +487,7 @@ resource "mso_schema_template_external_epg_subnet" "%[1]s_subnet" {
 func testTenantConfigTwoSites() string {
 	return fmt.Sprintf(`
 resource "mso_tenant" "%[1]s" {
-	name         = "%[1]s"
-	display_name = "%[1]s"
+	name = "%[1]s"
 	site_associations {
 		site_id = data.mso_site.%[2]s.id
 	}
@@ -504,8 +503,7 @@ resource "mso_tenant" "%[1]s" {
 func testTenantConfigOneSite(tenantName string) string {
 	return fmt.Sprintf(`
 resource "mso_tenant" "%[1]s" {
-	name         = "%[1]s"
-	display_name = "%[1]s"
+	name = "%[1]s"
 	site_associations {
 		site_id = data.mso_site.%[2]s.id
 	}


### PR DESCRIPTION
1. Remove deprecated mso_tenant display_name from shared config.
2. Add version check support to tests.

### Tests requiring version gating (ND 3.2 unsupported)

| Feature | Affected Tests | Issue |
|---|---|---|
| `endpointMacTagPolicies` | `TestAccMSOTenantPoliciesEndpointMACTagPolicyResource`, `TestAccMSOTenantPoliciesEndpointMACTagPolicyDataSource` | Whole resource unsupported |
| `netFlowExporters` | `TestAccMSOTenantPoliciesNetflowExporterResource`, `TestAccMSOTenantPoliciesNetflowExporterDataSource` | Whole resource unsupported |
| `netFlowMonitors` | `TestAccMSOTenantPoliciesNetflowMonitorResource`, `TestAccMSOTenantPoliciesNetflowMonitorDataSource` | Whole resource unsupported |
| `netFlowRecords` | `TestAccMSOTenantPoliciesNetflowRecordResource`, `TestAccMSOTenantPoliciesNetflowRecordDataSource` | Whole resource unsupported |