### PR TITLE
[ignore] Use add instead of replace for template_bd vmac PATCH (DCNE-866)

### DIFF
--- a/mso/resource_mso_schema_template_bd.go
+++ b/mso/resource_mso_schema_template_bd.go
@@ -836,7 +836,10 @@ func resourceMSOTemplateBDUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if d.HasChange("virtual_mac_address") {
-		err := addPatchPayloadToContainer(payloadCon, "replace", fmt.Sprintf("%s/vmac", basePath), d.Get("virtual_mac_address").(string))
+		// "add" is used instead of "replace" because vmac is omitted from the Create payload when empty.
+		// On NDO < 5.1, the field is absent from the stored document until first set,
+		// so "replace" (RFC 6902) would fail with "doc is missing key". "add" creates or replaces safely.
+		err := addPatchPayloadToContainer(payloadCon, "add", fmt.Sprintf("%s/vmac", basePath), d.Get("virtual_mac_address").(string))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix virtual_mac_address update failing on NDO < 5.1 (ND 3.2)

When a BD template is created without virtual_mac_address, NDO does not store the vmac field in the document at all. On NDO < 5.1, a subsequent replace PATCH operation (RFC 6902) fails with doc is missing key: vmac because the key was never initialised.

Changes

 - Use add instead of replace when patching vmac on update. The add operation creates the key if absent and replaces it if present, making it safe across all NDO versions.

Testing

 - Confirmed failure on ND 3.2 with replace (reproduces the error exactly)
 - Confirmed passing on ND 3.2 with add fix applied
 - Confirmed passing on ND 4.1 with add fix applied
 - Verified that other attributes on mso_schema_template_bd that use replace (ep_move_detection_mode, dhcpLabels) are unaffected — NDO initialises those fields so the key is always present
 - Verified that other resources with similar patterns (mso_schema_template_contract priority/target_dscp, mso_schema_template_vrf ip_data_plane_learning, mso_schema_site_bd svi_mac) also pass with replace on ND 3.2 — confirming the issue is isolated to vmac