### PR TITLE
[minor_change] Deprecate `user_associations` attribute in `mso_tenant` resource: on Nexus Dashboard 4.2+ (DCNE-877)

### DIFF
--- a/mso/provider_test.go
+++ b/mso/provider_test.go
@@ -315,6 +315,21 @@ func testAccVersionCheck(t *testing.T, minVersion string) {
 	}
 }
 
+// testAccVersionLessThanCheck skips the test unless the controller version
+// reported by CompareVersion is less than maxVersionExclusive.
+// Must be called after testAccPreCheck in the same PreCheck function.
+func testAccVersionLessThanCheck(t *testing.T, maxVersionExclusive string) {
+	t.Helper()
+	result, err := msoClientTest.CompareVersion(maxVersionExclusive)
+	if err != nil {
+		t.Skipf("Skipping: could not determine NDO version: %s", err)
+	}
+
+	if result <= 0 {
+		t.Skipf("Skipping: requires NDO version < %s", maxVersionExclusive)
+	}
+}
+
 // CustomTestCheckCollectionElemAttrsByKeys locates the TypeSet element whose
 // attributes match every key/value pair in matchAttrs and compares every key
 // in attrsToCheck against the value stored in state, producing a

--- a/mso/resource_mso_tenant.go
+++ b/mso/resource_mso_tenant.go
@@ -71,6 +71,11 @@ func resourceMSOTenant() *schema.Resource {
 				},
 				Optional: true,
 				Computed: true,
+				Deprecated: "On Nexus Dashboard 4.2+ user associations are automatically " +
+					"derived from Tenant Domain membership and are immutable via the tenants " +
+					"endpoint. The API may return additional users (for example, all-tenants-domain) " +
+					"and reject updates that remove them, causing perpetual drift. Do not set " +
+					"user_associations on ND 4.2+.",
 			},
 
 			"site_associations": &schema.Schema{
@@ -354,21 +359,13 @@ func resourceMSOTenantImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 		site_associations = append(site_associations, mapSite)
 	}
 	d.Set("site_associations", site_associations)
-	count2, _ := con.ArrayCount("userAssociations")
+	userAssociations, err := tenantUserAssociationsFromContainer(con)
 	if err != nil {
-		d.Set("user_assocoations", make([]interface{}, 0))
+		return nil, err
 	}
-	user_associations := make([]interface{}, 0)
-	for i := 0; i < count2; i++ {
-		usersCont, err := con.ArrayElement(i, "userAssociations")
-		if err != nil {
-			return nil, fmt.Errorf("Unable to parse the user associations list")
-		}
-		mapUser := make(map[string]interface{})
-		mapUser["user_id"] = models.StripQuotes(usersCont.S("userId").String())
-		user_associations = append(user_associations, mapUser)
+	if err := d.Set("user_associations", userAssociations); err != nil {
+		return nil, err
 	}
-	d.Set("user_associations", user_associations)
 	log.Printf("[DEBUG] %s: Tenant Import finished successfully", d.Id())
 	return []*schema.ResourceData{d}, nil
 }
@@ -551,8 +548,8 @@ func resourceMSOTenantCreate(d *schema.ResourceData, m interface{}) error {
 			inner := val.(map[string]interface{})
 			if inner["user_id"] != "" {
 				mapUser["userId"] = fmt.Sprintf("%v", inner["user_id"])
+				user_associations = append(user_associations, mapUser)
 			}
-			user_associations = append(user_associations, mapUser)
 		}
 	}
 	tenantAttr.Users = user_associations
@@ -748,8 +745,8 @@ func resourceMSOTenantUpdate(d *schema.ResourceData, m interface{}) error {
 			inner := val.(map[string]interface{})
 			if inner["user_id"] != "" {
 				mapUser["userId"] = fmt.Sprintf("%v", inner["user_id"])
+				user_associations = append(user_associations, mapUser)
 			}
-			user_associations = append(user_associations, mapUser)
 		}
 	}
 	tenantAttr.Users = user_associations
@@ -773,6 +770,31 @@ func setCloudAccountInfo(accInfo string, mapSite map[string]interface{}) {
 		mapSite["azure_access_type"] = "shared"
 		mapSite["azure_shared_account_id"] = accInfo[strings.Index(accInfo, "[")+1 : strings.Index(accInfo, "]")]
 	}
+}
+
+func tenantUserAssociationsFromContainer(con *container.Container) ([]interface{}, error) {
+	userAssociations := make([]interface{}, 0)
+	count, err := con.ArrayCount("userAssociations")
+	if err != nil {
+		return userAssociations, nil
+	}
+
+	for i := 0; i < count; i++ {
+		usersCont, err := con.ArrayElement(i, "userAssociations")
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse the user associations list")
+		}
+
+		mapUser := make(map[string]interface{})
+		userID := models.StripQuotes(usersCont.S("userId").String())
+		if userID == "" {
+			continue
+		}
+		mapUser["user_id"] = userID
+		userAssociations = append(userAssociations, mapUser)
+	}
+
+	return userAssociations, nil
 }
 
 func resourceMSOTenantRead(d *schema.ResourceData, m interface{}) error {
@@ -818,25 +840,13 @@ func resourceMSOTenantRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.Set("site_associations", site_associations)
-
-	count2, _ := con.ArrayCount("userAssociations")
+	userAssociations, err := tenantUserAssociationsFromContainer(con)
 	if err != nil {
-		d.Set("user_assocoations", make([]interface{}, 0))
+		return err
 	}
-
-	user_associations := make([]interface{}, 0)
-	for i := 0; i < count2; i++ {
-		usersCont, err := con.ArrayElement(i, "userAssociations")
-		if err != nil {
-			return fmt.Errorf("Unable to parse the user associations list")
-		}
-
-		mapUser := make(map[string]interface{})
-		mapUser["user_id"] = models.StripQuotes(usersCont.S("userId").String())
-		user_associations = append(user_associations, mapUser)
+	if err := d.Set("user_associations", userAssociations); err != nil {
+		return err
 	}
-
-	d.Set("user_associations", user_associations)
 
 	log.Printf("[DEBUG] %s: Read finished successfully", d.Id())
 	return nil

--- a/mso/resource_mso_tenant_test.go
+++ b/mso/resource_mso_tenant_test.go
@@ -1,8 +1,9 @@
 package mso
 
-// Note: User association tests are skipped because the mso_user data source uses
-// api/v1/users (or api/v2/users on ND), which no longer works on ND 4.1+ where
-// the endpoint changed to /api/v1/infra/aaa/localUsers.
+// Note: user_associations is only round-trip tested on platforms where the
+// legacy tenant API preserves explicit associations. ND 4.2+ back-fills
+// Tenant-domain users into userAssociations and rejects their removal, so that
+// behavior is intentionally skipped here.
 //
 // Note: Cloud site association tests (AWS/Azure/GCP) are skipped because they
 // require real cloud account credentials and vendor-specific configuration that
@@ -10,15 +11,19 @@ package mso
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/ciscoecosystem/mso-go-client/client"
+	"github.com/ciscoecosystem/mso-go-client/container"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // msoTenantId is used to capture the tenant ID from the first test step for use in the manual delete/recreate step.
 var msoTenantId string
+var msoTenantNameUserAssociations = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 func TestAccMSOTenantResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -122,6 +127,55 @@ func TestAccMSOTenantResource(t *testing.T) {
 	})
 }
 
+func TestAccMSOTenantResourceUserAssociations(t *testing.T) {
+	resourceRef := "mso_tenant.tenant_user_associations"
+
+	msoClient := testAccPreCheck(t)
+	userID, err := testAccMSOTenantLookupUserID(msoClient, os.Getenv("MSO_USERNAME"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccVersionLessThanCheck(t, "5.2.0.0") },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMsoTenantDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { fmt.Println("Test: Create Tenant with user association") },
+				Config:    testAccMSOTenantConfigUserAssociations("Terraform test tenant user association", userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRef, "name", msoTenantNameUserAssociations),
+					resource.TestCheckResourceAttr(resourceRef, "display_name", msoTenantNameUserAssociations),
+					resource.TestCheckResourceAttr(resourceRef, "description", "Terraform test tenant user association"),
+					CustomTestCheckTypeSetElemAttrs(resourceRef, "user_associations", map[string]string{
+						"user_id": userID,
+					}),
+				),
+			},
+			{
+				PreConfig: func() { fmt.Println("Test: Update Tenant with same user association") },
+				Config:    testAccMSOTenantConfigUserAssociations("Terraform test tenant user association updated", userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRef, "description", "Terraform test tenant user association updated"),
+					CustomTestCheckTypeSetElemAttrs(resourceRef, "user_associations", map[string]string{
+						"user_id": userID,
+					}),
+				),
+			},
+			{
+				PreConfig:         func() { fmt.Println("Test: Import Tenant with user association") },
+				ResourceName:      resourceRef,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"orchestrator_only",
+				},
+			},
+		},
+	})
+}
+
 func testAccMSOTenantConfigCreate() string {
 	return fmt.Sprintf(`
 	resource "mso_tenant" "tenant" {
@@ -184,6 +238,19 @@ func testAccMSOTenantConfigRemoveSiteAssociation() string {
 	}`, testSiteConfigAnsibleTest(), msoTenantName, msoTenantName, msoTemplateSiteName1)
 }
 
+func testAccMSOTenantConfigUserAssociations(description, userID string) string {
+	return fmt.Sprintf(`
+	resource "mso_tenant" "tenant_user_associations" {
+		name         = "%s"
+		display_name = "%s"
+		description  = "%s"
+
+		user_associations {
+			user_id = "%s"
+		}
+	}`, msoTenantNameUserAssociations, msoTenantNameUserAssociations, description, userID)
+}
+
 // testAccCheckMsoTenantDestroy verifies that the tenant is deleted from MSO.
 // The generic testCheckResourceDestroyPolicy helpers cannot be used here because
 // they query the policy/template API (api/v1/templates/objects), whereas tenants
@@ -203,6 +270,75 @@ func testAccCheckMsoTenantDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func testAccMSOTenantLookupUserID(msoClient *client.Client, username string) (string, error) {
+	paths := []string{"api/v1/users"}
+	if msoClient.GetPlatform() == "nd" {
+		paths = append(paths, "api/v2/users")
+	}
+
+	var lastErr error
+	for _, path := range paths {
+		con, err := msoClient.GetViaURL(path)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if userID, ok := testAccMSOTenantFindUserIDInContainer(con, username); ok {
+			return userID, nil
+		}
+	}
+
+	if lastErr != nil {
+		return "", fmt.Errorf("failed to look up user %q for tenant user_associations test: %w", username, lastErr)
+	}
+	return "", fmt.Errorf("user %q not found for tenant user_associations test", username)
+}
+
+func testAccMSOTenantFindUserIDInContainer(con *container.Container, username string) (string, bool) {
+	if users, ok := con.Data().([]interface{}); ok {
+		for _, user := range users {
+			userMap, ok := user.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if userID, ok := testAccMSOTenantMatchUserMap(userMap, username); ok {
+				return userID, true
+			}
+		}
+	}
+
+	if users, ok := con.S("users").Data().([]interface{}); ok {
+		for _, user := range users {
+			userMap, ok := user.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if userID, ok := testAccMSOTenantMatchUserMap(userMap, username); ok {
+				return userID, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func testAccMSOTenantMatchUserMap(userMap map[string]interface{}, username string) (string, bool) {
+	for _, key := range []string{"loginID", "username"} {
+		if fmt.Sprintf("%v", userMap[key]) != username {
+			continue
+		}
+
+		for _, idKey := range []string{"userID", "id"} {
+			if userID := fmt.Sprintf("%v", userMap[idKey]); userID != "" && userID != "<nil>" {
+				return userID, true
+			}
+		}
+	}
+
+	return "", false
 }
 
 // TestAccMSOTenantResourceDisplayNameDefault validates that display_name is

--- a/website/docs/r/tenant.html.markdown
+++ b/website/docs/r/tenant.html.markdown
@@ -105,8 +105,11 @@ resource "mso_tenant" "tenant4" {
 
 * `description` - (Optional) The description for this tenant.
 * `orchestrator_only` - (Optional) Option to delete this tenant only from orchestrator or not. Default value is "false".
-* `user_associations` - (Optional) A list of associated users for this tenant.
-* `user_associations.user_id` - (Optional) Id of user to be associated to this tenant.
+* `user_associations` - (Optional) **Deprecated** A list of associated users for this tenant.
+
+  !> **Deprecated Warning:** On Nexus Dashboard 4.2+ user associations are derived from Tenant Domain membership and are immutable via the tenants endpoint. The API can return additional users (for example, from `all-tenants-domain`) and reject updates that remove them, causing perpetual drift. Do not set `user_associations` on ND 4.2+.
+
+* `user_associations.user_id` - (Optional) **Deprecated** Id of user to be associated to this tenant.
 * `site_association` - (Optional) A list of associated sites for this tenant.
 * `site_association.site_id` - (Optional) Id of site to associate with this Tenant.
 * `site_association.security_domains` - (Optional) Security domains to associate with this Site.


### PR DESCRIPTION
## Summary

Deprecates `user_associations` guidance in `mso_tenant` for ND 4.2+ / NDO 5.2+, where tenant user associations are derived from Tenant Domain membership and are effectively immutable via the tenants endpoint.

## What changed

- Updated `mso_tenant` schema deprecation text for `user_associations` to document ND 4.2+ behavior and perpetual drift risk.
- Updated resource docs (`website/docs/r/tenant.html.markdown`) with ND 4.2+ deprecation.

## Validation

Acceptance tests run in parallel for `TestAccMSOTenantResource*`:

- ND 3.2: pass
- ND 4.1: pass
- ND 4.2: pass with `TestAccMSOTenantResourceUserAssociations` skipped by version gate