### PR TITLE
Service graph chain filter validation (DCNE-887)

### DIFF
--- a/mso/datasource_mso_schema_site_contract_service_graph_test.go
+++ b/mso/datasource_mso_schema_site_contract_service_graph_test.go
@@ -30,14 +30,14 @@ func TestAccMSOSchemaSiteContractServiceGraphDatasource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					fmt.Println("DataSource: Lookup site contract with no service graph relationship (expect error)")
+					fmt.Println("Test: Lookup site contract with no service graph relationship (expect error)")
 				},
 				Config:      testAccMSOSchemaSiteContractServiceGraphDatasourceNotFoundConfig(),
 				ExpectError: regexp.MustCompile(`No service graph found`),
 			},
 			{
 				PreConfig: func() {
-					fmt.Println("DataSource: Read existing site contract service graph and verify attributes match resource")
+					fmt.Println("Test: Read existing site contract service graph and verify attributes match resource")
 				},
 				Config: testAccMSOSchemaSiteContractServiceGraphDatasourceReadConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/mso/datasource_mso_schema_template_contract_service_graph_test.go
+++ b/mso/datasource_mso_schema_template_contract_service_graph_test.go
@@ -20,12 +20,12 @@ func TestAccMSOSchemaTemplateContractServiceGraphDatasource(t *testing.T) {
 			{
 				// Contract exists but no service graph relationship has been created yet.
 				// This directly tests the new not-found handling in the datasource.
-				PreConfig:   func() { fmt.Println("DataSource: Lookup contract with no service graph relationship (expect error)") },
+				PreConfig:   func() { fmt.Println("Test: Lookup contract with no service graph relationship (expect error)") },
 				Config:      testAccMSOSchemaTemplateContractServiceGraphDatasourceNotFoundConfig(),
 				ExpectError: regexp.MustCompile(`service graph relationship not found`),
 			},
 			{
-				PreConfig: func() { fmt.Println("DataSource: Read existing contract service graph") },
+				PreConfig: func() { fmt.Println("Test: Read existing contract service graph") },
 				Config:    testAccMSOSchemaTemplateContractServiceGraphDatasourceReadConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceRef, "schema_id", resourceRef, "schema_id"),

--- a/mso/resource_mso_schema_template_contract_service_chaining_test.go
+++ b/mso/resource_mso_schema_template_contract_service_chaining_test.go
@@ -242,14 +242,7 @@ resource "mso_service_device_cluster" "%[11]s" {
 	}
 }
 
-resource "mso_schema_template_filter_entry" "%[12]s" {
-	schema_id          = mso_schema.%[5]s.id
-	template_name      = "%[6]s"
-	name               = "%[12]s"
-	display_name       = "%[12]s"
-	entry_name         = "%[12]s_entry"
-	entry_display_name = "%[12]s_entry"
-}
+%[15]s
 
 resource "mso_schema_template_contract" "%[13]s" {
 	schema_id     = mso_schema.%[5]s.id
@@ -286,20 +279,21 @@ resource "mso_schema_template_external_epg_contract" "%[14]s_provider" {
 	contract_template_name = mso_schema_template_contract.%[13]s.template_name
 }
 `,
-		testSiteConfigAnsibleTest(),   // %[1]s
-		testTenantConfig(),            // %[2]s
-		msoServiceDeviceTemplateName,  // %[3]s
-		msoTenantName,                 // %[4]s
-		msoSchemaName,                 // %[5]s
-		msoSchemaTemplateName,         // %[6]s
-		msoSchemaTemplateVrfName,      // %[7]s
-		msoSchemaTemplateBdName,       // %[8]s
-		msoSchemaTemplateBdName2,      // %[9]s
-		msoServiceDeviceClusterLbName, // %[10]s
-		msoServiceDeviceClusterFwName, // %[11]s
-		msoSchemaTemplateFilterName,   // %[12]s
-		msoSchemaTemplateContractName, // %[13]s
-		msoSchemaTemplateExtEpgName,   // %[14]s
+		testSiteConfigAnsibleTest(),           // %[1]s
+		testTenantConfig(),                    // %[2]s
+		msoServiceDeviceTemplateName,          // %[3]s
+		msoTenantName,                         // %[4]s
+		msoSchemaName,                         // %[5]s
+		msoSchemaTemplateName,                 // %[6]s
+		msoSchemaTemplateVrfName,              // %[7]s
+		msoSchemaTemplateBdName,               // %[8]s
+		msoSchemaTemplateBdName2,              // %[9]s
+		msoServiceDeviceClusterLbName,         // %[10]s
+		msoServiceDeviceClusterFwName,         // %[11]s
+		msoSchemaTemplateFilterName,           // %[12]s
+		msoSchemaTemplateContractName,         // %[13]s
+		msoSchemaTemplateExtEpgName,           // %[14]s
+		testSchemaTemplateFilterEntryConfig(), // %[15]s
 	)
 }
 

--- a/mso/test_constants.go
+++ b/mso/test_constants.go
@@ -392,6 +392,7 @@ resource "mso_schema_template_filter_entry" "%[1]s" {
 	display_name       = "%[1]s"
 	entry_name         = "%[1]s_entry"
 	entry_display_name = "%[1]s_entry"
+	ether_type         = "ip"
 }
 `, msoSchemaTemplateFilterName, msoSchemaName, msoSchemaTemplateName)
 }


### PR DESCRIPTION
Tracked in Jira DCNE-887

## Summary

ND 4.3 rejects service graphs and service chains associated with contracts whose filters use the default or unspecified EtherType:

> Contract associated with ServiceChain/ServiceGraph cannot have filter using default/unspecified etherType

This change:

- Updates the shared schema-template filter fixture to set `ether_type = "ip"` and reuses it in the contract service-chaining tests.
- Uses consistent `Test:` logging in the affected datasource tests.
- Supports configurable test site names for ND 4.3 environments where site names use dashes instead of underscores.

These changes only affect acceptance-test configuration and logging. Provider runtime behavior is unchanged.

## Test results

Ran all 18 acceptance tests that directly or indirectly use the shared filter fixture.

```text
--- PASS: TestAccMSOSchemaSiteContractServiceGraphDatasource (32.41s)
--- PASS: TestAccMSOSchemaTemplateAnpEpgContractDatasource (16.64s)
--- PASS: TestAccMSOSchemaTemplateContractServiceChainingDataSource (20.62s)
--- PASS: TestAccMSOSchemaTemplateContractServiceGraphDatasource (19.38s)
--- PASS: TestAccMSOSchemaTemplateContractDatasource (14.73s)
--- PASS: TestAccMSOSchemaTemplateExternalEpgContractDatasource (16.40s)
--- PASS: TestAccMSOSchemaTemplateVrfContractDatasource (17.55s)
--- PASS: TestAccMSOSchemaSiteContractServiceGraphResource (54.70s)
--- PASS: TestAccMSOSchemaTemplateAnpEpgContractResource (30.80s)
--- PASS: TestAccMSOSchemaTemplateAnpEpgResource (71.40s)
--- PASS: TestAccMSOSchemaTemplateContractServiceChainingResource (37.54s)
--- PASS: TestAccMSOSchemaTemplateContractServiceGraphResource (30.00s)
--- PASS: TestAccMSOSchemaTemplateContractResourceTwoWay (55.86s)
--- PASS: TestAccMSOSchemaTemplateContractResourceOneWay (18.63s)
--- PASS: TestAccMSOSchemaTemplateExternalEpgContractResource (30.58s)
--- PASS: TestAccMSOSchemaTemplateExternalEpgResource (68.36s)
--- PASS: TestAccMSOSchemaTemplateVrfContractResource (24.65s)
--- PASS: TestAccMSOSchemaTemplateVrfResource (65.04s)

PASS
ok github.com/CiscoDevNet/terraform-provider-mso/mso 625.306s