### PR TITLE
[bugfix] Fix issue with mso_template resource and datasource when no templates exist (DCNE-889)

### DIFF
--- a/mso/resource_mso_template.go
+++ b/mso/resource_mso_template.go
@@ -306,9 +306,15 @@ func (ndoTemplate *ndoTemplate) setTemplateId() error {
 		return err
 	}
 
-	templates, err := cont.Children()
-	if err != nil {
-		return err
+	// The API returns a literal JSON null (instead of an empty array) when no
+	// templates exist yet, which cont.Children() cannot parse. Treat that as
+	// zero templates rather than surfacing a raw parsing error.
+	var templates []*container.Container
+	if cont.Data() != nil {
+		templates, err = cont.Children()
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, template := range templates {


### PR DESCRIPTION
When no templates exist in NDO a literal "null" string is returned. This fix handles this case the same as no templates existing. 

Tests:

MSO URL: https://10.15.39.129/
Site 1: ansible-test
Site 2: ansible-test-2

  PASSED (10)
────────────────────────────────────────────────────────────────────────
  ✔  TestAccMSOTemplateDatasourceTenantErrors  (17.38s)
  ✔  TestAccMSOTemplateDatasourceTenantName  (25.26s)
  ✔  TestAccMSOTemplateDatasourceTenantId  (27.92s)
  ✔  TestAccMSOTemplateResourceTenant  (171.27s)
  ✔  TestAccMSOTemplateResourceL3out  (42.87s)
  ✔  TestAccMSOTemplateResourceFabricPolicy  (24.92s)
  ✔  TestAccMSOTemplateResourceFabricResource  (25.90s)
  ✔  TestAccMSOTemplateResourceMonitoringTenant  (45.57s)
  ✔  TestAccMSOTemplateResourceMonitoringAccess  (44.71s)
  ✔  TestAccMSOTemplateResourceServiceDevice  (35.61s)

────────────────────────────────────────────────────────────────────────
  Total: 10   Passed: 10   Failed: 0   Skipped: 0   Elapsed: 477.3s
────────────────────────────────────────────────────────────────────────