### PR TITLE
[bugfix] Fix sensitive key attribute in mso_fabric_policies_mcp_global_policy resource and datasource for ND 4.3+ (DCNE-886)

### DIFF
--- a/mso/datasource_mso_fabric_policies_mcp_global_policy.go
+++ b/mso/datasource_mso_fabric_policies_mcp_global_policy.go
@@ -38,8 +38,9 @@ func datasourceMSOMCPGlobalPolicy() *schema.Resource {
 				Computed: true,
 			},
 			"key": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"loop_detect_multiplication_factor": {
 				Type:     schema.TypeInt,

--- a/mso/resource_mso_fabric_policies_mcp_global_policy.go
+++ b/mso/resource_mso_fabric_policies_mcp_global_policy.go
@@ -51,9 +51,10 @@ func resourceMSOMCPGlobalPolicy() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"enabled", "disabled"}, false),
 			},
 			"key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"loop_detect_multiplication_factor": {
 				Type:         schema.TypeInt,
@@ -102,7 +103,15 @@ func setMCPGlobalPolicyData(d *schema.ResourceData, response *container.Containe
 	d.Set("admin_state", models.StripQuotes(response.S("adminState").String()))
 
 	if response.Exists("key") {
-		d.Set("key", models.StripQuotes(response.S("key").String()))
+		apiKey := models.StripQuotes(response.S("key").String())
+		// The API returns a masked placeholder ("***") instead of the plaintext
+		// value for this sensitive field. Preserve the previously configured
+		// plaintext value from state to avoid perpetual diffs.
+		if apiKey == "***" {
+			d.Set("key", d.Get("key").(string))
+		} else {
+			d.Set("key", apiKey)
+		}
 	} else {
 		d.Set("key", nil)
 	}

--- a/website/docs/d/fabric_policies_mcp_global_policy.html.markdown
+++ b/website/docs/d/fabric_policies_mcp_global_policy.html.markdown
@@ -33,7 +33,7 @@ data "mso_fabric_policies_mcp_global_policy" "test" {
 * `description` - (Read-Only) The description of the MCP Global Policy.
 * `admin_state` - (Read-Only) The administrative state of the MCP Global Policy.
 * `enable_mcp_pdu_per_vlan` - (Read-Only) Enable MCP PDU per VLAN. This enables MCP to send packets on a per-EPG basis.
-* `key` - (Read-Only) The key to uniquely identify the MCP packets within the fabric.
+* `key` - (Read-Only) The key to uniquely identify the MCP packets within the fabric. This value is marked sensitive and will not be displayed in plan output.
 * `loop_detect_multiplication_factor` - (Read-Only) The number of MCP packets that will be received by the ACI fabric before the Loop Protection Action occurs.
 * `port_disable_protection` - (Read-Only) Enable or disable port disable protection for the MCP Global Policy.
 * `initial_delay_time` - (Read-Only) The time in seconds before MCP starts taking action. During this period, MCP will only generate syslog entries if a loop is detected, without taking protective action.

--- a/website/docs/r/fabric_policies_mcp_global_policy.html.markdown
+++ b/website/docs/r/fabric_policies_mcp_global_policy.html.markdown
@@ -39,7 +39,7 @@ resource "mso_fabric_policies_mcp_global_policy" "test" {
 * `description` - (Optional) The description of the MCP Global Policy.
 * `admin_state` - (Optional) The administrative state of the MCP Global Policy. Allowed values are `enabled` or `disabled`. Defaults to `disabled` when unset during creation.
 * `enable_mcp_pdu_per_vlan` - (Optional) Enable MCP PDU per VLAN. This enables MCP to send packets on a per-EPG basis. Allowed values are `enabled` or `disabled`. Defaults to `disabled` when unset during creation.
-* `key` - (Optional) The key to uniquely identify the MCP packets within the fabric. This must be provided when `admin_state` is set to `enabled`.
+* `key` - (Optional) The key to uniquely identify the MCP packets within the fabric. This must be provided when `admin_state` is set to `enabled`. This value is marked sensitive and will not be displayed in plan output.
 * `loop_detect_multiplication_factor` - (Optional) The number of MCP packets that will be received by the ACI fabric before the Loop Protection Action occurs. Valid range: 1-255. Defaults to `3` when unset during creation.
 * `port_disable_protection` - (Optional) Enable or disable port disable protection for the MCP Global Policy. Allowed values are `enabled` or `disabled`. Defaults to `enabled` when unset during creation.
 * `initial_delay_time` - (Optional) The time in seconds before MCP starts taking action. During this period, MCP will only generate syslog entries if a loop is detected, without taking protective action. Valid range: 0-1800. Defaults to `180` when unset during creation.


### PR DESCRIPTION


Summary

Fixes  mso_fabric_policies_mcp_global_policy  on ND 4.3+ / NDO 5.3+, where the API always returns a masked  "***"  for  key  instead of the real value, causing state to be overridden and perpetual plan diffs.

Fix

- setMCPGlobalPolicyData() : when the API returns  "***"  for  key , preserve the existing state value instead of overwriting it.
- Marked  key  as  Sensitive: true  in the resource and data source (same pattern as  macsec_policy 's  psk ), and updated docs.

Testing

- Verified on ND 4.3 & ND 4.2:  
    - TestAccMSOFabricPoliciesMCPGlobalPolicyResource  and  TestAccMSOMCPGlobalPolicyDataSource  both PASS.
- Confirmed the API masks  key  unconditionally (even when configured literally as  "***" ), the fix is safe with no ambiguity.

 Sensitive: true  only affects CLI output redaction — no state format change or migration needed.

```
════════════════════════════════════════════════════════════════════════
  Running tests  filter: MCPGlobal
════════════════════════════════════════════════════════════════════════

=== RUN   TestAccMSOMCPGlobalPolicyDataSource
Test: MCP Global Policy Data Source
--- PASS: TestAccMSOMCPGlobalPolicyDataSource (21.45s)
=== RUN   TestAccMSOFabricPoliciesMCPGlobalPolicyResource
Test: Create MCP Global Policy
Test: Import MCP Global Policy
Test: Update MCP Global Policy
Test: Update MCP Global Policy without key and admin_state is disabled
Test: Update MCP Global Policy without key when the admin_state enabled again
--- PASS: TestAccMSOFabricPoliciesMCPGlobalPolicyResource (50.58s)
PASS
coverage: 2.0% of statements
ok      github.com/CiscoDevNet/terraform-provider-mso/mso       72.370s coverage: 2.0% of statements

════════════════════════════════════════════════════════════════════════
  Test Report
════════════════════════════════════════════════════════════════════════
MSO URL: https://10.15.39.129/
Site 1: ansible-test
Site 2: ansible-test-2

  PASSED (2)
────────────────────────────────────────────────────────────────────────
  ✔  TestAccMSOMCPGlobalPolicyDataSource  (21.45s)
  ✔  TestAccMSOFabricPoliciesMCPGlobalPolicyResource  (50.58s)

────────────────────────────────────────────────────────────────────────
  Total: 2   Passed: 2   Failed: 0   Skipped: 0   Elapsed: 76s
────────────────────────────────────────────────────────────────────────
```